### PR TITLE
feat (Health) : ALB 헬스체크 API 추가

### DIFF
--- a/src/main/java/com/dnd/moyeolak/global/controller/HealthController.java
+++ b/src/main/java/com/dnd/moyeolak/global/controller/HealthController.java
@@ -1,0 +1,19 @@
+package com.dnd.moyeolak.global.controller;
+
+import com.dnd.moyeolak.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Health", description = "헬스체크 API")
+@RestController
+public class HealthController {
+
+    @Operation(summary = "헬스체크", description = "서버 상태를 확인합니다.")
+    @GetMapping("/health")
+    public ResponseEntity<ApiResponse<Void>> health() {
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+}


### PR DESCRIPTION
## Issue Number
#37

## As-Is
<!-- 문제 상황 정의 -->
- ALB에서 서버 상태를 확인할 수 있는 헬스체크 엔드포인트가 없음

## To-Be
<!-- 변경 사항 -->
- `GET /health` 헬스체크 API 추가
- `global/controller/HealthController` 클래스 생성

## Review Request (중요)
- 코드 리뷰는 **한국어로 작성**해주세요.
- 구현 의도, 리스크, 개선 포인트 중심으로 리뷰 부탁드립니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [ ] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
ALB 타겟 그룹 헬스체크 경로: `/health`