### PR TITLE
feat(ci): GitHub Actions CI 워크플로우 추가 (#34)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI - Test & Coverage
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - dev
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run tests with JaCoCo
+        run: ./gradlew test jacocoTestReport
+
+      - name: Verify coverage threshold
+        run: ./gradlew jacocoTestCoverageVerification
+
+      - name: Upload JaCoCo report
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: build/reports/jacoco/test/html/
+
+      - name: Add coverage to PR comment
+        uses: madrapps/jacoco-report@v1.7.1
+        if: github.event_name == 'pull_request'
+        with:
+          paths: build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
+          title: "📊 JaCoCo Coverage Report"
+          update-comment: true

--- a/src/test/java/com/dnd/moyeolak/MoyeolakApplicationTests.java
+++ b/src/test/java/com/dnd/moyeolak/MoyeolakApplicationTests.java
@@ -2,8 +2,10 @@ package com.dnd.moyeolak;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class MoyeolakApplicationTests {
 
     @Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -12,3 +12,11 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+kakao:
+  api:
+    key: test-kakao-api-key
+
+odsay:
+  api:
+    key: test-odsay-api-key


### PR DESCRIPTION
## 📋 Summary

- GitHub Actions를 활용한 CI 파이프라인 구축
- PR/Push 시 자동 테스트 실행 및 JaCoCo 커버리지 리포트 생성
- PR에 커버리지 결과 자동 코멘트 기능 추가

## 🔄 CI 워크플로우 구조

### 트리거 조건
| 이벤트 | 대상 브랜치 |
|--------|-------------|
| `push` | `dev` |
| `pull_request` | `dev`, `main` |

### 파이프라인 흐름

```mermaid
flowchart TD
    A[🚀 Trigger: Push/PR] --> B[📥 Checkout Code]
    B --> C[☕ Set up JDK 25]
    C --> D[🔑 Grant gradlew Permission]
    D --> E[🧪 Run Tests + JaCoCo Report]
    E --> F{테스트 성공?}
    F -->|Yes| G[✅ Verify Coverage ≥ 70%]
    F -->|No| X[❌ CI 실패]
    G --> H[📦 Upload JaCoCo Report]
    H --> I{PR 이벤트?}
    I -->|Yes| J[💬 PR에 커버리지 코멘트]
    I -->|No| K[✅ CI 완료]
    J --> K
```

### 주요 단계 설명

| 단계 | 설명 |
|------|------|
| **Checkout** | `actions/checkout@v4`로 코드 체크아웃 |
| **JDK Setup** | Temurin JDK 25 설치 (`actions/setup-java@v4`) |
| **Test & Report** | `./gradlew test jacocoTestReport` 실행 |
| **Coverage Verification** | 최소 커버리지 70% 검증 (`jacocoTestCoverageVerification`) |
| **Artifact Upload** | HTML 리포트를 `jacoco-report` 아티팩트로 저장 |
| **PR Comment** | `madrapps/jacoco-report@v1.7.1`로 PR에 커버리지 자동 코멘트 |

### 커버리지 정책

```
min-coverage-overall: 70%
min-coverage-changed-files: 70%
```

## 📁 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `.github/workflows/ci.yml` | CI 워크플로우 신규 추가 |
| `MoyeolakApplicationTests.java` | `@ActiveProfiles("test")` 추가 |
| `application-test.yml` | kakao/odsay API 테스트 키 설정 추가 |

## ✅ Test Plan

- [ ] dev 브랜치로 PR 생성 시 CI 워크플로우 실행 확인
- [ ] 테스트 통과 및 JaCoCo 리포트 생성 확인
- [ ] PR에 커버리지 코멘트 자동 추가 확인
- [ ] 커버리지 70% 미달 시 CI 실패 확인

🤖 Generated with [Claude Code](https://claude.ai/code)