### PR TITLE
feat: 참여자 생성 API 및 로컬 환경 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: moyeolak-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: moyeolak
+      MYSQL_USER: moyeolak
+      MYSQL_PASSWORD: moyeolak
+      TZ: Asia/Seoul
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+
+volumes:
+  mysql_data:

--- a/docs/local-dev-setup.md
+++ b/docs/local-dev-setup.md
@@ -1,0 +1,161 @@
+# 로컬 개발 환경 세팅 가이드
+
+## 사전 요구사항
+
+- Docker & Docker Compose
+- Gradle
+
+---
+
+## 1. MySQL 컨테이너 실행
+
+프로젝트 루트에서 Docker Compose로 MySQL을 실행합니다.
+
+```bash
+# 컨테이너 실행 (백그라운드)
+docker-compose up -d
+
+# 컨테이너 상태 확인
+docker ps
+```
+
+### MySQL 접속 정보
+
+| 항목 | 값 |
+|------|-----|
+| Host | localhost |
+| Port | 3306 |
+| Database | moyeolak |
+| Username | moyeolak |
+| Password | moyeolak |
+
+### 컨테이너 관리 명령어
+
+```bash
+# 컨테이너 중지
+docker-compose down
+
+# 컨테이너 중지 + 데이터 삭제
+docker-compose down -v
+
+# 로그 확인
+docker-compose logs -f mysql
+```
+
+---
+
+## 2. Spring Boot 실행
+
+`local` 프로파일로 애플리케이션을 실행합니다.
+
+```bash
+./gradlew bootRun --args='--spring.profiles.active=local'
+```
+
+### IDE에서 실행 (IntelliJ)
+
+1. Run/Debug Configurations 열기
+2. Active profiles에 `local` 입력
+3. 실행
+
+---
+
+## 3. 초기 데이터
+
+서버 시작 시 `data.sql`이 자동 실행되어 테스트 데이터가 생성됩니다.
+
+### 생성되는 데이터
+
+| 테이블 | 개수 | 설명 |
+|--------|------|------|
+| meeting | 10개 | test-meeting-001 ~ 010 |
+| schedule_poll | 10개 | 각 모임당 1개 (14일 날짜 옵션) |
+| location_poll | 10개 | 각 모임당 1개 |
+| participant | 10명 | 각 모임 방장 1명 |
+
+### 테스트 모임 ID 목록
+
+```
+test-meeting-001  (방장: 김민준)
+test-meeting-002  (방장: 이서연)
+test-meeting-003  (방장: 박도윤)
+test-meeting-004  (방장: 최하은)
+test-meeting-005  (방장: 정시우)
+test-meeting-006  (방장: 강지아)
+test-meeting-007  (방장: 조예준)
+test-meeting-008  (방장: 윤수아)
+test-meeting-009  (방장: 임건우)
+test-meeting-010  (방장: 한지유)
+```
+
+---
+
+## 4. 설정 파일 구조
+
+```
+src/main/resources/
+├── application.yml          # 공통 설정 (프로파일 지정)
+├── application-local.yml    # 로컬 환경 설정
+├── application-prod.yml     # 운영 환경 설정
+└── data.sql                 # 초기 데이터 (local에서만 실행)
+```
+
+### application-local.yml 주요 설정
+
+| 설정 | 값 | 설명 |
+|------|-----|------|
+| ddl-auto | create | 서버 시작 시 테이블 재생성 |
+| defer-datasource-initialization | true | JPA 초기화 후 data.sql 실행 |
+| sql.init.mode | always | data.sql 항상 실행 |
+
+---
+
+## 5. 데이터 유지하고 싶을 때
+
+테이블 재생성 없이 데이터를 유지하려면 `application-local.yml`을 수정합니다.
+
+```yaml
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: update  # create -> update로 변경
+  sql:
+    init:
+      mode: never       # always -> never로 변경
+```
+
+---
+
+## 6. 트러블슈팅
+
+### 포트 충돌 (3306 사용 중)
+
+```bash
+# 사용 중인 프로세스 확인
+lsof -i :3306
+
+# docker-compose.yml에서 포트 변경
+ports:
+  - "3307:3306"  # 호스트 포트를 3307로 변경
+
+# application-local.yml도 수정
+url: jdbc:mysql://localhost:3307/moyeolak?...
+```
+
+### 컨테이너 접속
+
+```bash
+# MySQL CLI 접속
+docker exec -it moyeolak-mysql mysql -u moyeolak -pmoyeolak moyeolak
+
+# 컨테이너 쉘 접속
+docker exec -it moyeolak-mysql bash
+```
+
+### 데이터 초기화
+
+```bash
+# 볼륨 삭제 후 재시작
+docker-compose down -v
+docker-compose up -d
+```

--- a/src/main/java/com/dnd/moyeolak/domain/location/entity/LocationVote.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/entity/LocationVote.java
@@ -33,4 +33,15 @@ public class LocationVote {
 
     @Column(comment = "출발지 경도", nullable = false, precision = 10, scale = 7)
     private BigDecimal departureLng;
+
+    public static LocationVote of(LocationPoll locationPoll, Participant participant,
+                                  String departureLocation, BigDecimal departureLat, BigDecimal departureLng) {
+        return LocationVote.builder()
+                .locationPoll(locationPoll)
+                .participant(participant)
+                .departureLocation(departureLocation)
+                .departureLat(departureLat)
+                .departureLng(departureLng)
+                .build();
+    }
 }

--- a/src/main/java/com/dnd/moyeolak/domain/location/repository/LocationPollRepository.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/repository/LocationPollRepository.java
@@ -1,0 +1,12 @@
+package com.dnd.moyeolak.domain.location.repository;
+
+import com.dnd.moyeolak.domain.location.entity.LocationPoll;
+import com.dnd.moyeolak.domain.meeting.entity.Meeting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LocationPollRepository extends JpaRepository<LocationPoll, Long> {
+
+    Optional<LocationPoll> findByMeeting(Meeting meeting);
+}

--- a/src/main/java/com/dnd/moyeolak/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/dnd/moyeolak/domain/meeting/controller/MeetingController.java
@@ -32,8 +32,8 @@ public class MeetingController {
 
     @GetMapping("/{id}/schedules")
     @Operation(summary = "모임 일정 조회", description = "특정 모임의 일정을 조회합니다.")
-    public ResponseEntity<ApiResponse<GetMeetingScheduleResponse>> getMeetingSchedules(@PathVariable("id") String meetingId) {
-        GetMeetingScheduleResponse meetingSchedules = meetingService.getMeetingSchedules(meetingId);
+    public ResponseEntity<ApiResponse<GetMeetingScheduleResponse>> getMeetingSchedules(@PathVariable String id) {
+        GetMeetingScheduleResponse meetingSchedules = meetingService.getMeetingSchedules(id);
         return ResponseEntity.ok(ApiResponse.success(meetingSchedules));
     }
 
@@ -42,12 +42,5 @@ public class MeetingController {
     public ResponseEntity<ApiResponse<String>> createMeeting(@RequestBody CreateMeetingRequest request) {
         String meetingId = meetingService.createMeeting(request);
         return ResponseEntity.ok(ApiResponse.success(meetingId));
-    }
-
-    @DeleteMapping
-    @Operation(summary = "모임 삭제", description = "특정 모임을 삭제합니다.")
-    public ResponseEntity<ApiResponse<Void>> deleteMeeting(@RequestParam("meetingId") String meetingId) {
-        meetingService.deleteMeeting(meetingId);
-        return ResponseEntity.ok(ApiResponse.success());
     }
 }

--- a/src/main/java/com/dnd/moyeolak/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/dnd/moyeolak/domain/meeting/controller/MeetingController.java
@@ -31,4 +31,11 @@ public class MeetingController {
         String meetingId = meetingService.createMeeting(request);
         return ResponseEntity.ok(ApiResponse.success(meetingId));
     }
+
+    @DeleteMapping
+    @Operation(summary = "모임 삭제", description = "특정 모임을 삭제합니다.")
+    public ResponseEntity<ApiResponse<Void>> deleteMeeting(@RequestParam("meetingId") String meetingId) {
+        meetingService.deleteMeeting(meetingId);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
 }

--- a/src/main/java/com/dnd/moyeolak/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/dnd/moyeolak/domain/meeting/controller/MeetingController.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Tag(name = "Meeting", description = "모임 관련 API")
 @RestController
 @RequestMapping("/api/meetings")
@@ -17,6 +19,16 @@ import org.springframework.web.bind.annotation.*;
 public class MeetingController {
 
     private final MeetingService meetingService;
+
+    @GetMapping("/all")
+    @Operation(summary = "[TEST] 모임 전체 조회", description = """
+            모든 모임의 ID를 조회합니다.
+            현재 DB에 저장되어 있는 모임 ID를 가져오기 위한 테스트 용도로만 사용됩니다.
+            """)
+    public ResponseEntity<ApiResponse<List<String>>> getAllMeetings() {
+        List<String> allMeetings = meetingService.findAllMeetings();
+        return ResponseEntity.ok(ApiResponse.success(allMeetings));
+    }
 
     @GetMapping("/{id}/schedules")
     @Operation(summary = "모임 일정 조회", description = "특정 모임의 일정을 조회합니다.")

--- a/src/main/java/com/dnd/moyeolak/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/dnd/moyeolak/domain/meeting/repository/MeetingRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MeetingRepository extends JpaRepository<Meeting, String> {
@@ -32,4 +33,9 @@ public interface MeetingRepository extends JpaRepository<Meeting, String> {
         WHERE m.meetingId = :meetingId
     """)
     Optional<Meeting> findByIdWithAllAssociations(@Param("meetingId") String meetingId);
+
+    @Query("""
+        SELECT m.meetingId FROM Meeting m
+    """)
+    List<String> findAllMeetingsId();
 }

--- a/src/main/java/com/dnd/moyeolak/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/dnd/moyeolak/domain/meeting/repository/MeetingRepository.java
@@ -23,4 +23,13 @@ public interface MeetingRepository extends JpaRepository<Meeting, String> {
         WHERE m.meetingId = :meetingId
     """)
     Optional<Meeting> findByIdWithScheduleVotes(@Param("meetingId") String meetingId);
+
+    @Query("""
+        SELECT m FROM Meeting m
+        LEFT JOIN FETCH m.schedulePoll
+        LEFT JOIN FETCH m.locationPoll
+        LEFT JOIN FETCH m.participants
+        WHERE m.meetingId = :meetingId
+    """)
+    Optional<Meeting> findByIdWithAllAssociations(@Param("meetingId") String meetingId);
 }

--- a/src/main/java/com/dnd/moyeolak/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/dnd/moyeolak/domain/meeting/service/MeetingService.java
@@ -3,11 +3,15 @@ package com.dnd.moyeolak.domain.meeting.service;
 import com.dnd.moyeolak.domain.meeting.dto.CreateMeetingRequest;
 import com.dnd.moyeolak.domain.meeting.dto.GetMeetingScheduleResponse;
 
+import java.util.List;
+
 public interface MeetingService {
 
     String createMeeting(CreateMeetingRequest request);
 
     GetMeetingScheduleResponse getMeetingSchedules(String meetingId);
+
+    List<String> findAllMeetings();
 
     void deleteMeeting(String meetingId);
 }

--- a/src/main/java/com/dnd/moyeolak/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/dnd/moyeolak/domain/meeting/service/MeetingService.java
@@ -8,4 +8,6 @@ public interface MeetingService {
     String createMeeting(CreateMeetingRequest request);
 
     GetMeetingScheduleResponse getMeetingSchedules(String meetingId);
+
+    void deleteMeeting(String meetingId);
 }

--- a/src/main/java/com/dnd/moyeolak/domain/meeting/service/impl/MeetingServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/meeting/service/impl/MeetingServiceImpl.java
@@ -44,4 +44,13 @@ public class MeetingServiceImpl implements MeetingService {
 
         return GetMeetingScheduleResponse.from(meeting);
     }
+
+    @Override
+    @Transactional
+    public void deleteMeeting(String meetingId) {
+        Meeting meeting = meetingRepository.findByIdWithAllAssociations(meetingId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));
+
+        meetingRepository.delete(meeting);
+    }
 }

--- a/src/main/java/com/dnd/moyeolak/domain/meeting/service/impl/MeetingServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/meeting/service/impl/MeetingServiceImpl.java
@@ -14,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -43,6 +45,11 @@ public class MeetingServiceImpl implements MeetingService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));
 
         return GetMeetingScheduleResponse.from(meeting);
+    }
+
+    @Override
+    public List<String> findAllMeetings() {
+        return meetingRepository.findAllMeetingsId();
     }
 
     @Override

--- a/src/main/java/com/dnd/moyeolak/domain/participant/controller/ParticipantController.java
+++ b/src/main/java/com/dnd/moyeolak/domain/participant/controller/ParticipantController.java
@@ -1,0 +1,50 @@
+package com.dnd.moyeolak.domain.participant.controller;
+
+import com.dnd.moyeolak.domain.participant.dto.CreateParticipantResponse;
+import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithLocationRequest;
+import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithScheduleRequest;
+import com.dnd.moyeolak.domain.participant.service.ParticipantService;
+import com.dnd.moyeolak.global.response.ApiResponse;
+import com.dnd.moyeolak.global.response.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Participant", description = "참여자 관련 API")
+@RestController
+@RequestMapping("/api/meetings/{meetingId}/participants")
+@RequiredArgsConstructor
+public class ParticipantController {
+
+    private final ParticipantService participantService;
+
+    @PostMapping("/schedule")
+    @Operation(summary = "일정 기반 참여자 생성", description = "참여자와 가능한 시간대 투표를 함께 생성합니다.")
+    public ResponseEntity<ApiResponse<CreateParticipantResponse>> createWithSchedule(
+            @PathVariable String meetingId,
+            @Valid @RequestBody CreateParticipantWithScheduleRequest request) {
+
+        CreateParticipantResponse response = participantService.createWithSchedule(meetingId, request);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(SuccessCode.RESOURCE_CREATED, response));
+    }
+
+    @PostMapping("/location")
+    @Operation(summary = "위치 기반 참여자 생성", description = "참여자와 출발지 위치 투표를 함께 생성합니다.")
+    public ResponseEntity<ApiResponse<CreateParticipantResponse>> createWithLocation(
+            @PathVariable String meetingId,
+            @Valid @RequestBody CreateParticipantWithLocationRequest request) {
+
+        CreateParticipantResponse response = participantService.createWithLocation(meetingId, request);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(SuccessCode.RESOURCE_CREATED, response));
+    }
+}

--- a/src/main/java/com/dnd/moyeolak/domain/participant/dto/CreateParticipantResponse.java
+++ b/src/main/java/com/dnd/moyeolak/domain/participant/dto/CreateParticipantResponse.java
@@ -1,0 +1,44 @@
+package com.dnd.moyeolak.domain.participant.dto;
+
+import com.dnd.moyeolak.domain.participant.entity.Participant;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "참여자 생성 응답")
+public record CreateParticipantResponse(
+        @Schema(description = "참여자 ID", example = "1")
+        Long participantId,
+
+        @Schema(description = "참여자 이름", example = "김철수")
+        String name,
+
+        @Schema(description = "일정 투표 수 (일정 기반 생성 시)", example = "3")
+        Integer scheduleVoteCount,
+
+        @Schema(description = "위치 정보 보유 여부 (위치 기반 생성 시)", example = "true")
+        Boolean hasLocation,
+
+        @Schema(description = "생성 일시", example = "2025-02-05T10:30:00")
+        LocalDateTime createdAt
+) {
+    public static CreateParticipantResponse fromSchedule(Participant participant, int voteCount) {
+        return new CreateParticipantResponse(
+                participant.getParticipantId(),
+                participant.getName(),
+                voteCount,
+                false,
+                participant.getCreatedAt()
+        );
+    }
+
+    public static CreateParticipantResponse fromLocation(Participant participant) {
+        return new CreateParticipantResponse(
+                participant.getParticipantId(),
+                participant.getName(),
+                null,
+                true,
+                participant.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/dnd/moyeolak/domain/participant/dto/CreateParticipantWithLocationRequest.java
+++ b/src/main/java/com/dnd/moyeolak/domain/participant/dto/CreateParticipantWithLocationRequest.java
@@ -1,0 +1,45 @@
+package com.dnd.moyeolak.domain.participant.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+
+import java.math.BigDecimal;
+
+@Schema(description = "위치 기반 참여자 생성 요청")
+public record CreateParticipantWithLocationRequest(
+        @Schema(description = "참여자 이름", example = "이영희")
+        @NotBlank(message = "이름은 필수입니다")
+        @Size(max = 50, message = "이름은 50자를 초과할 수 없습니다")
+        String name,
+
+        @Schema(description = "브라우저 식별 키 (UUID 권장)", example = "550e8400-e29b-41d4-a716-446655440001")
+        @NotBlank(message = "localStorageKey는 필수입니다")
+        @Size(max = 100, message = "localStorageKey는 100자를 초과할 수 없습니다")
+        String localStorageKey,
+
+        @Schema(description = "출발지 위치 정보")
+        @NotNull(message = "위치 정보는 필수입니다")
+        @Valid
+        LocationInput location
+) {
+    @Schema(description = "출발지 위치 정보")
+    public record LocationInput(
+            @Schema(description = "위도 (-90 ~ 90)", example = "37.5665")
+            @NotNull(message = "위도는 필수입니다")
+            @DecimalMin(value = "-90", message = "위도는 -90 이상이어야 합니다")
+            @DecimalMax(value = "90", message = "위도는 90 이하여야 합니다")
+            BigDecimal latitude,
+
+            @Schema(description = "경도 (-180 ~ 180)", example = "126.9780")
+            @NotNull(message = "경도는 필수입니다")
+            @DecimalMin(value = "-180", message = "경도는 -180 이상이어야 합니다")
+            @DecimalMax(value = "180", message = "경도는 180 이하여야 합니다")
+            BigDecimal longitude,
+
+            @Schema(description = "출발지 주소", example = "서울시 중구 명동")
+            @Size(max = 255, message = "주소는 255자를 초과할 수 없습니다")
+            String address
+    ) {
+    }
+}

--- a/src/main/java/com/dnd/moyeolak/domain/participant/dto/CreateParticipantWithScheduleRequest.java
+++ b/src/main/java/com/dnd/moyeolak/domain/participant/dto/CreateParticipantWithScheduleRequest.java
@@ -1,0 +1,35 @@
+package com.dnd.moyeolak.domain.participant.dto;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "일정 기반 참여자 생성 요청")
+public record CreateParticipantWithScheduleRequest(
+        @Schema(description = "참여자 이름", example = "김철수")
+        @NotBlank(message = "이름은 필수입니다")
+        @Size(max = 50, message = "이름은 50자를 초과할 수 없습니다")
+        String name,
+
+        @Schema(description = "브라우저 식별 키 (UUID 권장)", example = "550e8400-e29b-41d4-a716-446655440000")
+        @NotBlank(message = "localStorageKey는 필수입니다")
+        @Size(max = 100, message = "localStorageKey는 100자를 초과할 수 없습니다")
+        String localStorageKey,
+
+        @ArraySchema(
+                schema = @Schema(description = "가능한 시간 (30분 단위)"),
+                arraySchema = @Schema(
+                        description = "참여 가능한 시간대 목록",
+                        example = "[\"2025-02-10T09:00:00\", \"2025-02-10T09:30:00\", \"2025-02-10T10:00:00\", \"2025-02-10T14:00:00\"]"
+                )
+        )
+        @NotEmpty(message = "가능한 시간 정보는 필수입니다")
+        List<@NotNull LocalDateTime> availableSchedules
+) {
+}

--- a/src/main/java/com/dnd/moyeolak/domain/participant/dto/CreateParticipantWithScheduleRequest.java
+++ b/src/main/java/com/dnd/moyeolak/domain/participant/dto/CreateParticipantWithScheduleRequest.java
@@ -23,10 +23,15 @@ public record CreateParticipantWithScheduleRequest(
         String localStorageKey,
 
         @ArraySchema(
-                schema = @Schema(description = "가능한 시간 (30분 단위)"),
+                schema = @Schema(
+                        description = "가능한 시간 (30분 단위, ISO-8601, Asia/Seoul 기준)",
+                        type = "string",
+                        format = "date-time",
+                        example = "2025-02-10T09:00:00"
+                ),
                 arraySchema = @Schema(
-                        description = "참여 가능한 시간대 목록",
-                        example = "[\"2025-02-10T09:00:00\", \"2025-02-10T09:30:00\", \"2025-02-10T10:00:00\", \"2025-02-10T14:00:00\"]"
+                        description = "참여 가능한 시간대 목록 (선호 순서대로 최대 20개)",
+                        example = "[\"2025-02-10T09:00:00\", \"2025-02-10T09:30:00\", \"2025-02-10T10:00:00\", \"2025-02-11T14:30:00\"]"
                 )
         )
         @NotEmpty(message = "가능한 시간 정보는 필수입니다")

--- a/src/main/java/com/dnd/moyeolak/domain/participant/entity/Participant.java
+++ b/src/main/java/com/dnd/moyeolak/domain/participant/entity/Participant.java
@@ -6,6 +6,7 @@ import com.dnd.moyeolak.domain.schedule.entity.ScheduleVote;
 import com.dnd.moyeolak.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,10 +33,12 @@ public class Participant extends BaseEntity {
     private String name;
 
     @Builder.Default
+    @BatchSize(size = 15)
     @OneToMany(mappedBy = "participant", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ScheduleVote> scheduleVotes = new ArrayList<>();
 
     @Builder.Default
+    @BatchSize(size = 15)
     @OneToMany(mappedBy = "participant", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<LocationVote> locationVotes = new ArrayList<>();
 

--- a/src/main/java/com/dnd/moyeolak/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/com/dnd/moyeolak/domain/participant/repository/ParticipantRepository.java
@@ -1,0 +1,10 @@
+package com.dnd.moyeolak.domain.participant.repository;
+
+import com.dnd.moyeolak.domain.meeting.entity.Meeting;
+import com.dnd.moyeolak.domain.participant.entity.Participant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+
+    boolean existsByMeetingAndLocalStorageKey(Meeting meeting, String localStorageKey);
+}

--- a/src/main/java/com/dnd/moyeolak/domain/participant/service/ParticipantService.java
+++ b/src/main/java/com/dnd/moyeolak/domain/participant/service/ParticipantService.java
@@ -1,0 +1,12 @@
+package com.dnd.moyeolak.domain.participant.service;
+
+import com.dnd.moyeolak.domain.participant.dto.CreateParticipantResponse;
+import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithLocationRequest;
+import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithScheduleRequest;
+
+public interface ParticipantService {
+
+    CreateParticipantResponse createWithSchedule(String meetingId, CreateParticipantWithScheduleRequest request);
+
+    CreateParticipantResponse createWithLocation(String meetingId, CreateParticipantWithLocationRequest request);
+}

--- a/src/main/java/com/dnd/moyeolak/domain/participant/service/impl/ParticipantServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/participant/service/impl/ParticipantServiceImpl.java
@@ -1,0 +1,101 @@
+package com.dnd.moyeolak.domain.participant.service.impl;
+
+import com.dnd.moyeolak.domain.location.entity.LocationPoll;
+import com.dnd.moyeolak.domain.location.entity.LocationVote;
+import com.dnd.moyeolak.domain.location.repository.LocationPollRepository;
+import com.dnd.moyeolak.domain.meeting.entity.Meeting;
+import com.dnd.moyeolak.domain.meeting.repository.MeetingRepository;
+import com.dnd.moyeolak.domain.participant.dto.CreateParticipantResponse;
+import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithLocationRequest;
+import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithScheduleRequest;
+import com.dnd.moyeolak.domain.participant.entity.Participant;
+import com.dnd.moyeolak.domain.participant.repository.ParticipantRepository;
+import com.dnd.moyeolak.domain.participant.service.ParticipantService;
+import com.dnd.moyeolak.domain.schedule.entity.SchedulePoll;
+import com.dnd.moyeolak.domain.schedule.entity.ScheduleVote;
+import com.dnd.moyeolak.domain.schedule.repository.SchedulePollRepository;
+import com.dnd.moyeolak.global.exception.BusinessException;
+import com.dnd.moyeolak.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ParticipantServiceImpl implements ParticipantService {
+
+    private final MeetingRepository meetingRepository;
+    private final ParticipantRepository participantRepository;
+    private final SchedulePollRepository schedulePollRepository;
+    private final LocationPollRepository locationPollRepository;
+
+    @Override
+    @Transactional
+    public CreateParticipantResponse createWithSchedule(String meetingId, CreateParticipantWithScheduleRequest request) {
+        Meeting meeting = findMeetingById(meetingId);
+
+        validateLocalStorageKeyUnique(meeting, request.localStorageKey());
+
+        SchedulePoll schedulePoll = schedulePollRepository.findByMeeting(meeting)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SCHEDULE_POLL_NOT_FOUND));
+
+        Participant participant = Participant.of(meeting, request.localStorageKey(), request.name());
+        meeting.addParticipant(participant);
+
+        List<ScheduleVote> scheduleVotes = createScheduleVotes(participant, schedulePoll, request.availableSchedules());
+        participant.getScheduleVotes().addAll(scheduleVotes);
+
+        participantRepository.save(participant);
+
+        return CreateParticipantResponse.fromSchedule(participant, scheduleVotes.size());
+    }
+
+    @Override
+    @Transactional
+    public CreateParticipantResponse createWithLocation(String meetingId, CreateParticipantWithLocationRequest request) {
+        Meeting meeting = findMeetingById(meetingId);
+
+        validateLocalStorageKeyUnique(meeting, request.localStorageKey());
+
+        LocationPoll locationPoll = locationPollRepository.findByMeeting(meeting)
+                .orElseThrow(() -> new BusinessException(ErrorCode.LOCATION_POLL_NOT_FOUND));
+
+        Participant participant = Participant.of(meeting, request.localStorageKey(), request.name());
+        meeting.addParticipant(participant);
+
+        LocationVote locationVote = LocationVote.of(
+                locationPoll,
+                participant,
+                request.location().address(),
+                request.location().latitude(),
+                request.location().longitude()
+        );
+        participant.getLocationVotes().add(locationVote);
+
+        participantRepository.save(participant);
+
+        return CreateParticipantResponse.fromLocation(participant);
+    }
+
+    private Meeting findMeetingById(String meetingId) {
+        return meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));
+    }
+
+    private void validateLocalStorageKeyUnique(Meeting meeting, String localStorageKey) {
+        if (participantRepository.existsByMeetingAndLocalStorageKey(meeting, localStorageKey)) {
+            throw new BusinessException(ErrorCode.DUPLICATE_LOCAL_STORAGE_KEY);
+        }
+    }
+
+    private List<ScheduleVote> createScheduleVotes(Participant participant, SchedulePoll schedulePoll,
+                                                   List<LocalDateTime> availableSchedules) {
+        return availableSchedules.stream()
+                .map(schedule -> ScheduleVote.of(participant, schedulePoll, schedule))
+                .toList();
+    }
+}

--- a/src/main/java/com/dnd/moyeolak/domain/schedule/entity/ScheduleVote.java
+++ b/src/main/java/com/dnd/moyeolak/domain/schedule/entity/ScheduleVote.java
@@ -27,4 +27,12 @@ public class ScheduleVote {
 
     @Column(columnDefinition = "DATETIME(0)", comment = "투표한 날짜", nullable = false)
     private LocalDateTime votedDate;
+
+    public static ScheduleVote of(Participant participant, SchedulePoll schedulePoll, LocalDateTime votedDate) {
+        return ScheduleVote.builder()
+                .participant(participant)
+                .schedulePoll(schedulePoll)
+                .votedDate(votedDate)
+                .build();
+    }
 }

--- a/src/main/java/com/dnd/moyeolak/domain/schedule/repository/SchedulePollRepository.java
+++ b/src/main/java/com/dnd/moyeolak/domain/schedule/repository/SchedulePollRepository.java
@@ -1,0 +1,12 @@
+package com.dnd.moyeolak.domain.schedule.repository;
+
+import com.dnd.moyeolak.domain.meeting.entity.Meeting;
+import com.dnd.moyeolak.domain.schedule.entity.SchedulePoll;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SchedulePollRepository extends JpaRepository<SchedulePoll, Long> {
+
+    Optional<SchedulePoll> findByMeeting(Meeting meeting);
+}

--- a/src/main/java/com/dnd/moyeolak/global/response/ErrorCode.java
+++ b/src/main/java/com/dnd/moyeolak/global/response/ErrorCode.java
@@ -19,6 +19,9 @@ public enum ErrorCode {
     NOT_FOUND("E404", "리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     DUPLICATE_RESOURCE("E409", "이미 존재하는 리소스입니다.", HttpStatus.CONFLICT),
     MEETING_NOT_FOUND("E410", "모임이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    SCHEDULE_POLL_NOT_FOUND("E411", "일정 투표판이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    LOCATION_POLL_NOT_FOUND("E412", "위치 투표판이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    DUPLICATE_LOCAL_STORAGE_KEY("E413", "이미 참여한 사용자입니다.", HttpStatus.CONFLICT),
 
     // 서버 오류
     SERVER_ERROR("E500", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/com/dnd/moyeolak/test/janghh/controller/OptimalLocationController.java
+++ b/src/main/java/com/dnd/moyeolak/test/janghh/controller/OptimalLocationController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
-@Tag(name = "Optimal Location", description = "참가자 위치를 바탕으로 최적 만남 장소를 추천하는 API")
+@Tag(name = "Optimal Location", description = "참가자 위치를 바탕으로 최적 만남 장소를 추천하는 테스트 API")
 @RestController
 @RequestMapping("/api/test/janghh/optimal-location")
 @RequiredArgsConstructor
@@ -29,7 +29,7 @@ public class OptimalLocationController {
     @PostMapping
     @Operation(
         summary = "최적 만남 장소 추천",
-        description = "참여자의 위도/경도 좌표를 받아 모임 중심점을 계산하고, 카카오/ODsay 탐색 결과를 기반으로 최적 장소 3곳을 추천합니다."
+        description = "참여자의 위도/경도 좌표를 받아 모임 중심점을 계산하고, 카카오/ODsay 탐색 결과를 기반으로 최적 장소 3곳을 추천하는 테스트 용도 API입니다."
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponse(
         responseCode = "200",

--- a/src/main/java/com/dnd/moyeolak/test/janghh/controller/OptimalLocationController.java
+++ b/src/main/java/com/dnd/moyeolak/test/janghh/controller/OptimalLocationController.java
@@ -4,12 +4,21 @@ import com.dnd.moyeolak.global.response.ApiResponse;
 import com.dnd.moyeolak.test.janghh.dto.request.OptimalLocationRequest;
 import com.dnd.moyeolak.test.janghh.dto.response.OptimalLocationResponse;
 import com.dnd.moyeolak.test.janghh.service.OptimalLocationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
+@Tag(name = "Optimal Location", description = "참가자 위치를 바탕으로 최적 만남 장소를 추천하는 API")
 @RestController
 @RequestMapping("/api/test/janghh/optimal-location")
 @RequiredArgsConstructor
@@ -18,7 +27,161 @@ public class OptimalLocationController {
     private final OptimalLocationService optimalLocationService;
 
     @PostMapping
+    @Operation(
+        summary = "최적 만남 장소 추천",
+        description = "참여자의 위도/경도 좌표를 받아 모임 중심점을 계산하고, 카카오/ODsay 탐색 결과를 기반으로 최적 장소 3곳을 추천합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "추천 계산 성공",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiResponse.class),
+            examples = @ExampleObject(
+                name = "성공 응답 예시",
+                value = """
+                        {
+                          "code": "S100",
+                          "data": {
+                            "centerPoint": {
+                              "latitude": 37.54217301784178,
+                              "longitude": 126.93569223930636
+                            },
+                            "recommendations": [
+                              {
+                                "rank": 1,
+                                "name": "마포역 5호선",
+                                "category": "지하철역",
+                                "address": "서울 마포구 도화동 160",
+                                "latitude": 37.53955402908912,
+                                "longitude": 126.94586257221307,
+                                "distanceFromCenter": 944,
+                                "minSum": 82,
+                                "minMax": 35,
+                                "avgDuration": 27.333333333333332,
+                                "routes": [
+                                  {
+                                    "participantName": "참여자1",
+                                    "duration": 28,
+                                    "distance": 16128,
+                                    "payment": 1750,
+                                    "transitCount": 2
+                                  },
+                                  {
+                                    "participantName": "참여자2",
+                                    "duration": 35,
+                                    "distance": 13922,
+                                    "payment": 2350,
+                                    "transitCount": 3
+                                  },
+                                  {
+                                    "participantName": "참여자3",
+                                    "duration": 19,
+                                    "distance": 5217,
+                                    "payment": 1550,
+                                    "transitCount": 1
+                                  }
+                                ]
+                              },
+                              {
+                                "rank": 2,
+                                "name": "서강대역 경의중앙선",
+                                "category": "지하철역",
+                                "address": "서울 마포구 노고산동 112-5",
+                                "latitude": 37.5521384864879,
+                                "longitude": 126.935507621173,
+                                "distanceFromCenter": 1106,
+                                "minSum": 91,
+                                "minMax": 44,
+                                "avgDuration": 30.333333333333332,
+                                "routes": [
+                                  {
+                                    "participantName": "참여자1",
+                                    "duration": 27,
+                                    "distance": 15233,
+                                    "payment": 1650,
+                                    "transitCount": 2
+                                  },
+                                  {
+                                    "participantName": "참여자2",
+                                    "duration": 44,
+                                    "distance": 12033,
+                                    "payment": 1500,
+                                    "transitCount": 1
+                                  },
+                                  {
+                                    "participantName": "참여자3",
+                                    "duration": 20,
+                                    "distance": 4341,
+                                    "payment": 1550,
+                                    "transitCount": 1
+                                  }
+                                ]
+                              },
+                              {
+                                "rank": 3,
+                                "name": "대흥역 6호선",
+                                "category": "지하철역",
+                                "address": "서울 마포구 대흥동 128-1",
+                                "latitude": 37.5476479056751,
+                                "longitude": 126.942473188734,
+                                "distanceFromCenter": 853,
+                                "minSum": 100,
+                                "minMax": 39,
+                                "avgDuration": 33.333333333333336,
+                                "routes": [
+                                  {
+                                    "participantName": "참여자1",
+                                    "duration": 33,
+                                    "distance": 18028,
+                                    "payment": 1750,
+                                    "transitCount": 2
+                                  },
+                                  {
+                                    "participantName": "참여자2",
+                                    "duration": 39,
+                                    "distance": 11222,
+                                    "payment": 1500,
+                                    "transitCount": 1
+                                  },
+                                  {
+                                    "participantName": "참여자3",
+                                    "duration": 28,
+                                    "distance": 5589,
+                                    "payment": 1500,
+                                    "transitCount": 1
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "message": "요청이 성공적으로 처리되었습니다."
+                        }
+                        """
+            )
+        )
+    )
     public ApiResponse<OptimalLocationResponse> findOptimalLocations(
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true,
+            description = "참가자들의 위도/경도 좌표 목록",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = OptimalLocationRequest.class),
+                examples = @ExampleObject(
+                    name = "요청 예시",
+                    value = """
+                            {
+                              "participants": [
+                                { "name": "참여자1", "latitude": 37.5621, "longitude": 126.8015 },
+                                { "name": "참여자2", "latitude": 37.4980, "longitude": 127.0276 },
+                                { "name": "참여자3", "latitude": 37.5663, "longitude": 126.9779 }
+                              ]
+                            }
+                            """
+                )
+            )
+        )
         @Valid @RequestBody OptimalLocationRequest request
     ) {
         log.info("최적 만남 장소 추천 요청: 참가자 {}명", request.participants().size());

--- a/src/main/java/com/dnd/moyeolak/test/janghh/dto/request/OptimalLocationRequest.java
+++ b/src/main/java/com/dnd/moyeolak/test/janghh/dto/request/OptimalLocationRequest.java
@@ -1,20 +1,34 @@
 package com.dnd.moyeolak.test.janghh.dto.request;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
+@Schema(description = "최적 만남 장소 요청")
 public record OptimalLocationRequest(
+    @ArraySchema(
+        schema = @Schema(implementation = ParticipantInfo.class),
+        arraySchema = @Schema(
+            description = "참여 가능한 인원의 위치 목록 (최소 2명, 최대 10명 권장)",
+            example = "[{\"name\":\"참여자1\",\"latitude\":37.5621,\"longitude\":126.8015},{\"name\":\"참여자2\",\"latitude\":37.4980,\"longitude\":127.0276},{\"name\":\"참여자3\",\"latitude\":37.5663,\"longitude\":126.9779}]"
+        )
+    )
     @NotEmpty(message = "참가자 정보는 필수입니다.")
     List<ParticipantInfo> participants
 ) {
+    @Schema(description = "참가자 위치 정보")
     public record ParticipantInfo(
+        @Schema(description = "참여자 이름", example = "참여자1")
         @NotNull(message = "참가자 이름은 필수입니다.")
         String name,
 
+        @Schema(description = "참여자 위도 (WGS84)", example = "37.5621")
         @NotNull(message = "위도는 필수입니다.")
         Double latitude,
 
+        @Schema(description = "참여자 경도 (WGS84)", example = "126.8015")
         @NotNull(message = "경도는 필수입니다.")
         Double longitude
     ) {}

--- a/src/main/java/com/dnd/moyeolak/test/janghh/dto/response/CenterPoint.java
+++ b/src/main/java/com/dnd/moyeolak/test/janghh/dto/response/CenterPoint.java
@@ -1,6 +1,12 @@
 package com.dnd.moyeolak.test.janghh.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "참가자들의 중심 좌표")
 public record CenterPoint(
+    @Schema(description = "중심점 위도", example = "37.54217301784178")
     double latitude,
+
+    @Schema(description = "중심점 경도", example = "126.93569223930636")
     double longitude
 ) {}

--- a/src/main/java/com/dnd/moyeolak/test/janghh/dto/response/EvaluatedPlace.java
+++ b/src/main/java/com/dnd/moyeolak/test/janghh/dto/response/EvaluatedPlace.java
@@ -1,17 +1,44 @@
 package com.dnd.moyeolak.test.janghh.dto.response;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
+@Schema(description = "평가된 추천 장소 정보")
 public record EvaluatedPlace(
+    @Schema(description = "추천 순위 (1=최적)", example = "1")
     int rank,
+
+    @Schema(description = "장소명", example = "마포역 5호선")
     String name,
+
+    @Schema(description = "장소 카테고리", example = "지하철역")
     String category,
+
+    @Schema(description = "주소", example = "서울 마포구 도화동 160")
     String address,
+
+    @Schema(description = "장소 위도", example = "37.53955402908912")
     double latitude,
+
+    @Schema(description = "장소 경도", example = "126.94586257221307")
     double longitude,
+
+    @Schema(description = "중심점과의 거리 (미터)", example = "944")
     int distanceFromCenter,
+
+    @Schema(description = "총 이동시간 합 (분)", example = "82")
     int minSum,
+
+    @Schema(description = "최대 이동시간 (분)", example = "35")
     int minMax,
+
+    @Schema(description = "평균 이동시간 (분)", example = "27.33")
     double avgDuration,
+
+    @ArraySchema(
+        schema = @Schema(implementation = RouteDetail.class),
+        arraySchema = @Schema(description = "각 참여자의 이동 경로 결과")
+    )
     List<RouteDetail> routes
 ) {}

--- a/src/main/java/com/dnd/moyeolak/test/janghh/dto/response/OptimalLocationResponse.java
+++ b/src/main/java/com/dnd/moyeolak/test/janghh/dto/response/OptimalLocationResponse.java
@@ -1,8 +1,17 @@
 package com.dnd.moyeolak.test.janghh.dto.response;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
+@Schema(description = "최적 만남 장소 추천 결과")
 public record OptimalLocationResponse(
+    @Schema(description = "모든 참가자의 중간 지점")
     CenterPoint centerPoint,
+
+    @ArraySchema(
+        schema = @Schema(implementation = EvaluatedPlace.class),
+        arraySchema = @Schema(description = "추천 장소 목록 (순위 오름차순, 최대 3개)")
+    )
     List<EvaluatedPlace> recommendations
 ) {}

--- a/src/main/java/com/dnd/moyeolak/test/janghh/dto/response/RouteDetail.java
+++ b/src/main/java/com/dnd/moyeolak/test/janghh/dto/response/RouteDetail.java
@@ -1,9 +1,21 @@
 package com.dnd.moyeolak.test.janghh.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "참가자별 이동 경로 요약")
 public record RouteDetail(
+    @Schema(description = "참가자 이름", example = "참여자1")
     String participantName,
+
+    @Schema(description = "소요 시간(분)", example = "28")
     int duration,
+
+    @Schema(description = "이동 거리(미터)", example = "16128")
     int distance,
+
+    @Schema(description = "요금(원)", example = "1750")
     int payment,
+
+    @Schema(description = "환승 횟수", example = "2")
     int transitCount
 ) {}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,19 +1,24 @@
 spring:
   datasource:
-    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    url: jdbc:mysql://localhost:3306/moyeolak?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: moyeolak
+    password: moyeolak
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
         format_sql: true
     show-sql: true
     open-in-view: false
+    defer-datasource-initialization: true
+
+  sql:
+    init:
+      mode: always
 
 kakao:
   api:

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,55 @@
+-- =====================================================
+-- 초기 테스트 데이터: 모임 10개 (각 모임당 방장 1명)
+-- =====================================================
+
+-- Meeting 10개
+INSERT INTO meeting (meeting_id, participant_count, created_at, updated_at) VALUES
+('test-meeting-001', 5, NOW(), NOW()),
+('test-meeting-002', 4, NOW(), NOW()),
+('test-meeting-003', 6, NOW(), NOW()),
+('test-meeting-004', 3, NOW(), NOW()),
+('test-meeting-005', 8, NOW(), NOW()),
+('test-meeting-006', 2, NOW(), NOW()),
+('test-meeting-007', 7, NOW(), NOW()),
+('test-meeting-008', 4, NOW(), NOW()),
+('test-meeting-009', 5, NOW(), NOW()),
+('test-meeting-010', 6, NOW(), NOW());
+
+-- SchedulePoll 10개 (각 모임당 1개, 14일간 날짜 옵션)
+INSERT INTO schedule_poll (meeting_id, date_options, start_time, end_time, confirmed_start_time, confirmed_end_time, poll_status, created_at, updated_at) VALUES
+('test-meeting-001', '["2025-02-05","2025-02-06","2025-02-07","2025-02-08","2025-02-09","2025-02-10","2025-02-11","2025-02-12","2025-02-13","2025-02-14","2025-02-15","2025-02-16","2025-02-17","2025-02-18"]', 7, 24, NULL, NULL, 'INACTIVE', NOW(), NOW()),
+('test-meeting-002', '["2025-02-05","2025-02-06","2025-02-07","2025-02-08","2025-02-09","2025-02-10","2025-02-11","2025-02-12","2025-02-13","2025-02-14","2025-02-15","2025-02-16","2025-02-17","2025-02-18"]', 7, 24, NULL, NULL, 'INACTIVE', NOW(), NOW()),
+('test-meeting-003', '["2025-02-05","2025-02-06","2025-02-07","2025-02-08","2025-02-09","2025-02-10","2025-02-11","2025-02-12","2025-02-13","2025-02-14","2025-02-15","2025-02-16","2025-02-17","2025-02-18"]', 7, 24, NULL, NULL, 'INACTIVE', NOW(), NOW()),
+('test-meeting-004', '["2025-02-05","2025-02-06","2025-02-07","2025-02-08","2025-02-09","2025-02-10","2025-02-11","2025-02-12","2025-02-13","2025-02-14","2025-02-15","2025-02-16","2025-02-17","2025-02-18"]', 7, 24, NULL, NULL, 'INACTIVE', NOW(), NOW()),
+('test-meeting-005', '["2025-02-05","2025-02-06","2025-02-07","2025-02-08","2025-02-09","2025-02-10","2025-02-11","2025-02-12","2025-02-13","2025-02-14","2025-02-15","2025-02-16","2025-02-17","2025-02-18"]', 7, 24, NULL, NULL, 'INACTIVE', NOW(), NOW()),
+('test-meeting-006', '["2025-02-05","2025-02-06","2025-02-07","2025-02-08","2025-02-09","2025-02-10","2025-02-11","2025-02-12","2025-02-13","2025-02-14","2025-02-15","2025-02-16","2025-02-17","2025-02-18"]', 7, 24, NULL, NULL, 'INACTIVE', NOW(), NOW()),
+('test-meeting-007', '["2025-02-05","2025-02-06","2025-02-07","2025-02-08","2025-02-09","2025-02-10","2025-02-11","2025-02-12","2025-02-13","2025-02-14","2025-02-15","2025-02-16","2025-02-17","2025-02-18"]', 7, 24, NULL, NULL, 'INACTIVE', NOW(), NOW()),
+('test-meeting-008', '["2025-02-05","2025-02-06","2025-02-07","2025-02-08","2025-02-09","2025-02-10","2025-02-11","2025-02-12","2025-02-13","2025-02-14","2025-02-15","2025-02-16","2025-02-17","2025-02-18"]', 7, 24, NULL, NULL, 'INACTIVE', NOW(), NOW()),
+('test-meeting-009', '["2025-02-05","2025-02-06","2025-02-07","2025-02-08","2025-02-09","2025-02-10","2025-02-11","2025-02-12","2025-02-13","2025-02-14","2025-02-15","2025-02-16","2025-02-17","2025-02-18"]', 7, 24, NULL, NULL, 'INACTIVE', NOW(), NOW()),
+('test-meeting-010', '["2025-02-05","2025-02-06","2025-02-07","2025-02-08","2025-02-09","2025-02-10","2025-02-11","2025-02-12","2025-02-13","2025-02-14","2025-02-15","2025-02-16","2025-02-17","2025-02-18"]', 7, 24, NULL, NULL, 'INACTIVE', NOW(), NOW());
+
+-- LocationPoll 10개 (각 모임당 1개)
+INSERT INTO location_poll (meeting_id, confirmed_location, confirmed_lat, confirmed_lng, poll_status, created_at, updated_at) VALUES
+('test-meeting-001', NULL, NULL, NULL, 'INACTIVE', NOW(), NOW()),
+('test-meeting-002', NULL, NULL, NULL, 'INACTIVE', NOW(), NOW()),
+('test-meeting-003', NULL, NULL, NULL, 'INACTIVE', NOW(), NOW()),
+('test-meeting-004', NULL, NULL, NULL, 'INACTIVE', NOW(), NOW()),
+('test-meeting-005', NULL, NULL, NULL, 'INACTIVE', NOW(), NOW()),
+('test-meeting-006', NULL, NULL, NULL, 'INACTIVE', NOW(), NOW()),
+('test-meeting-007', NULL, NULL, NULL, 'INACTIVE', NOW(), NOW()),
+('test-meeting-008', NULL, NULL, NULL, 'INACTIVE', NOW(), NOW()),
+('test-meeting-009', NULL, NULL, NULL, 'INACTIVE', NOW(), NOW()),
+('test-meeting-010', NULL, NULL, NULL, 'INACTIVE', NOW(), NOW());
+
+-- Participant 10명 (각 모임당 방장 1명)
+INSERT INTO participant (meeting_id, local_storage_key, name, created_at, updated_at) VALUES
+('test-meeting-001', 'host-key-001', '김민준', NOW(), NOW()),
+('test-meeting-002', 'host-key-002', '이서연', NOW(), NOW()),
+('test-meeting-003', 'host-key-003', '박도윤', NOW(), NOW()),
+('test-meeting-004', 'host-key-004', '최하은', NOW(), NOW()),
+('test-meeting-005', 'host-key-005', '정시우', NOW(), NOW()),
+('test-meeting-006', 'host-key-006', '강지아', NOW(), NOW()),
+('test-meeting-007', 'host-key-007', '조예준', NOW(), NOW()),
+('test-meeting-008', 'host-key-008', '윤수아', NOW(), NOW()),
+('test-meeting-009', 'host-key-009', '임건우', NOW(), NOW()),
+('test-meeting-010', 'host-key-010', '한지유', NOW(), NOW());

--- a/src/test/java/com/dnd/moyeolak/domain/participant/controller/ParticipantControllerTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/participant/controller/ParticipantControllerTest.java
@@ -1,0 +1,182 @@
+package com.dnd.moyeolak.domain.participant.controller;
+
+import com.dnd.moyeolak.domain.participant.dto.CreateParticipantResponse;
+import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithLocationRequest;
+import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithScheduleRequest;
+import com.dnd.moyeolak.domain.participant.service.ParticipantService;
+import com.dnd.moyeolak.global.exception.BusinessException;
+import com.dnd.moyeolak.global.exception.GlobalExceptionAdvice;
+import com.dnd.moyeolak.global.response.ErrorCode;
+import com.dnd.moyeolak.global.response.SuccessCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class ParticipantControllerTest {
+
+    private static final String MEETING_ID = "meeting-id";
+
+    @Mock
+    private ParticipantService participantService;
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        ParticipantController controller = new ParticipantController(participantService);
+        this.mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionAdvice())
+                .build();
+
+        this.objectMapper = new ObjectMapper();
+        this.objectMapper.registerModule(new JavaTimeModule());
+        this.objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    @Test
+    @DisplayName("일정 기반 참여자 생성 API 는 201 상태와 응답 본문을 반환한다")
+    void createWithSchedule_returnsCreatedResponse() throws Exception {
+        CreateParticipantWithScheduleRequest request = new CreateParticipantWithScheduleRequest(
+                "홍길동",
+                "local-key",
+                List.of(
+                        LocalDateTime.of(2025, 2, 10, 9, 0),
+                        LocalDateTime.of(2025, 2, 10, 10, 0)
+                )
+        );
+        CreateParticipantResponse response = new CreateParticipantResponse(
+                1L,
+                request.name(),
+                request.availableSchedules().size(),
+                false,
+                LocalDateTime.now()
+        );
+        when(participantService.createWithSchedule(eq(MEETING_ID), any(CreateParticipantWithScheduleRequest.class)))
+                .thenReturn(response);
+
+        mockMvc.perform(post("/api/meetings/{meetingId}/participants/schedule", MEETING_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.code").value(SuccessCode.RESOURCE_CREATED.getCode()))
+                .andExpect(jsonPath("$.data.participantId").value(response.participantId()))
+                .andExpect(jsonPath("$.data.scheduleVoteCount").value(response.scheduleVoteCount()))
+                .andExpect(jsonPath("$.data.hasLocation").value(false));
+
+        ArgumentCaptor<CreateParticipantWithScheduleRequest> captor =
+                ArgumentCaptor.forClass(CreateParticipantWithScheduleRequest.class);
+        verify(participantService).createWithSchedule(eq(MEETING_ID), captor.capture());
+        assertThat(captor.getValue()).isEqualTo(request);
+    }
+
+    @Test
+    @DisplayName("위치 기반 참여자 생성 API 는 201 상태와 응답 본문을 반환한다")
+    void createWithLocation_returnsCreatedResponse() throws Exception {
+        CreateParticipantWithLocationRequest request = new CreateParticipantWithLocationRequest(
+                "이영희",
+                "local-key",
+                new CreateParticipantWithLocationRequest.LocationInput(
+                        new BigDecimal("37.5665"),
+                        new BigDecimal("126.9780"),
+                        "서울시 중구 명동"
+                )
+        );
+        CreateParticipantResponse response = new CreateParticipantResponse(
+                2L,
+                request.name(),
+                null,
+                true,
+                LocalDateTime.now()
+        );
+        when(participantService.createWithLocation(eq(MEETING_ID), any(CreateParticipantWithLocationRequest.class)))
+                .thenReturn(response);
+
+        mockMvc.perform(post("/api/meetings/{meetingId}/participants/location", MEETING_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.code").value(SuccessCode.RESOURCE_CREATED.getCode()))
+                .andExpect(jsonPath("$.data.participantId").value(response.participantId()))
+                .andExpect(jsonPath("$.data.hasLocation").value(true))
+                .andExpect(jsonPath("$.data.scheduleVoteCount").doesNotExist());
+
+        ArgumentCaptor<CreateParticipantWithLocationRequest> captor =
+                ArgumentCaptor.forClass(CreateParticipantWithLocationRequest.class);
+        verify(participantService).createWithLocation(eq(MEETING_ID), captor.capture());
+        assertThat(captor.getValue()).isEqualTo(request);
+    }
+
+    @Test
+    @DisplayName("일정 기반 참여자 생성 API 는 요청 검증 실패 시 400을 반환한다")
+    void createWithSchedule_returnsBadRequestOnValidationError() throws Exception {
+        String invalidPayload = """
+                {
+                  "name": "",
+                  "localStorageKey": "",
+                  "availableSchedules": []
+                }
+                """;
+
+        mockMvc.perform(post("/api/meetings/{meetingId}/participants/schedule", MEETING_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(invalidPayload))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_PARAMETER.getCode()))
+                .andExpect(jsonPath("$.data.name").exists())
+                .andExpect(jsonPath("$.data.localStorageKey").exists())
+                .andExpect(jsonPath("$.data.availableSchedules").exists());
+
+        verifyNoInteractions(participantService);
+    }
+
+    @Test
+    @DisplayName("위치 기반 참여자 생성 API 는 비즈니스 예외 발생 시 에러 응답을 반환한다")
+    void createWithLocation_returnsErrorResponseWhenServiceThrowsBusinessException() throws Exception {
+        CreateParticipantWithLocationRequest request = new CreateParticipantWithLocationRequest(
+                "이영희",
+                "local-key",
+                new CreateParticipantWithLocationRequest.LocationInput(
+                        new BigDecimal("37.5665"),
+                        new BigDecimal("126.9780"),
+                        "서울시 중구 명동"
+                )
+        );
+        when(participantService.createWithLocation(eq(MEETING_ID), any(CreateParticipantWithLocationRequest.class)))
+                .thenThrow(new BusinessException(ErrorCode.LOCATION_POLL_NOT_FOUND));
+
+        mockMvc.perform(post("/api/meetings/{meetingId}/participants/location", MEETING_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().is(ErrorCode.LOCATION_POLL_NOT_FOUND.getHttpStatus().value()))
+                .andExpect(jsonPath("$.code").value(ErrorCode.LOCATION_POLL_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.LOCATION_POLL_NOT_FOUND.getMessage()));
+
+        verify(participantService).createWithLocation(eq(MEETING_ID), any(CreateParticipantWithLocationRequest.class));
+    }
+}

--- a/src/test/java/com/dnd/moyeolak/domain/participant/service/ParticipantServiceImplTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/participant/service/ParticipantServiceImplTest.java
@@ -1,0 +1,224 @@
+package com.dnd.moyeolak.domain.participant.service;
+
+import com.dnd.moyeolak.domain.location.entity.LocationPoll;
+import com.dnd.moyeolak.domain.meeting.entity.Meeting;
+import com.dnd.moyeolak.domain.meeting.repository.MeetingRepository;
+import com.dnd.moyeolak.domain.participant.dto.CreateParticipantResponse;
+import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithLocationRequest;
+import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithScheduleRequest;
+import com.dnd.moyeolak.domain.participant.entity.Participant;
+import com.dnd.moyeolak.domain.participant.repository.ParticipantRepository;
+import com.dnd.moyeolak.domain.participant.service.impl.ParticipantServiceImpl;
+import com.dnd.moyeolak.domain.schedule.entity.SchedulePoll;
+import com.dnd.moyeolak.domain.schedule.repository.SchedulePollRepository;
+import com.dnd.moyeolak.domain.location.repository.LocationPollRepository;
+import com.dnd.moyeolak.global.exception.BusinessException;
+import com.dnd.moyeolak.global.response.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ParticipantServiceImplTest {
+
+    private static final String MEETING_ID = "meeting-id";
+    private static final String LOCAL_STORAGE_KEY = "local-storage-key";
+
+    @Mock
+    private MeetingRepository meetingRepository;
+
+    @Mock
+    private ParticipantRepository participantRepository;
+
+    @Mock
+    private SchedulePollRepository schedulePollRepository;
+
+    @Mock
+    private LocationPollRepository locationPollRepository;
+
+    @InjectMocks
+    private ParticipantServiceImpl participantService;
+
+    @Test
+    @DisplayName("일정 투표 기반 참여자 생성 성공 시 투표 개수와 저장 여부를 반환한다")
+    void createWithSchedule_success() {
+        Meeting meeting = Meeting.of(10);
+        SchedulePoll schedulePoll = SchedulePoll.defaultOf(meeting);
+        CreateParticipantWithScheduleRequest request = new CreateParticipantWithScheduleRequest(
+                "홍길동",
+                LOCAL_STORAGE_KEY,
+                List.of(
+                        LocalDateTime.of(2025, 2, 10, 9, 0),
+                        LocalDateTime.of(2025, 2, 10, 10, 0)
+                )
+        );
+
+        when(meetingRepository.findById(MEETING_ID)).thenReturn(Optional.of(meeting));
+        when(participantRepository.existsByMeetingAndLocalStorageKey(meeting, LOCAL_STORAGE_KEY)).thenReturn(false);
+        when(schedulePollRepository.findByMeeting(meeting)).thenReturn(Optional.of(schedulePoll));
+
+        CreateParticipantResponse response = participantService.createWithSchedule(MEETING_ID, request);
+
+        assertThat(response.name()).isEqualTo(request.name());
+        assertThat(response.scheduleVoteCount()).isEqualTo(request.availableSchedules().size());
+        assertThat(response.hasLocation()).isFalse();
+
+        ArgumentCaptor<Participant> captor = ArgumentCaptor.forClass(Participant.class);
+        verify(participantRepository).save(captor.capture());
+        Participant savedParticipant = captor.getValue();
+        assertThat(savedParticipant.getScheduleVotes()).hasSize(2);
+        assertThat(savedParticipant.getScheduleVotes().get(0).getSchedulePoll()).isEqualTo(schedulePoll);
+        assertThat(savedParticipant.getScheduleVotes().get(0).getParticipant()).isEqualTo(savedParticipant);
+    }
+
+    @Test
+    @DisplayName("일정 투표 기반 참여자 생성 시 모임을 찾지 못하면 예외를 던진다")
+    void createWithSchedule_meetingNotFound() {
+        CreateParticipantWithScheduleRequest request = new CreateParticipantWithScheduleRequest(
+                "홍길동",
+                LOCAL_STORAGE_KEY,
+                List.of(LocalDateTime.of(2025, 2, 10, 9, 0))
+        );
+        when(meetingRepository.findById(MEETING_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> participantService.createWithSchedule(MEETING_ID, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MEETING_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("일정 투표 기반 참여자 생성 시 localStorageKey 중복이면 예외를 던진다")
+    void createWithSchedule_duplicateLocalStorageKey() {
+        Meeting meeting = Meeting.of(10);
+        CreateParticipantWithScheduleRequest request = new CreateParticipantWithScheduleRequest(
+                "홍길동",
+                LOCAL_STORAGE_KEY,
+                List.of(LocalDateTime.of(2025, 2, 10, 9, 0))
+        );
+
+        when(meetingRepository.findById(MEETING_ID)).thenReturn(Optional.of(meeting));
+        when(participantRepository.existsByMeetingAndLocalStorageKey(meeting, LOCAL_STORAGE_KEY)).thenReturn(true);
+
+        assertThatThrownBy(() -> participantService.createWithSchedule(MEETING_ID, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DUPLICATE_LOCAL_STORAGE_KEY);
+    }
+
+    @Test
+    @DisplayName("일정 투표 기반 참여자 생성 시 일정 투표판이 없으면 예외를 던진다")
+    void createWithSchedule_schedulePollNotFound() {
+        Meeting meeting = Meeting.of(10);
+        CreateParticipantWithScheduleRequest request = new CreateParticipantWithScheduleRequest(
+                "홍길동",
+                LOCAL_STORAGE_KEY,
+                List.of(LocalDateTime.of(2025, 2, 10, 9, 0))
+        );
+
+        when(meetingRepository.findById(MEETING_ID)).thenReturn(Optional.of(meeting));
+        when(participantRepository.existsByMeetingAndLocalStorageKey(meeting, LOCAL_STORAGE_KEY)).thenReturn(false);
+        when(schedulePollRepository.findByMeeting(meeting)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> participantService.createWithSchedule(MEETING_ID, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.SCHEDULE_POLL_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("위치 투표 기반 참여자 생성 성공 시 위치 투표 정보가 저장된다")
+    void createWithLocation_success() {
+        Meeting meeting = Meeting.of(10);
+        LocationPoll locationPoll = LocationPoll.defaultOf(meeting);
+        CreateParticipantWithLocationRequest request = new CreateParticipantWithLocationRequest(
+                "이영희",
+                LOCAL_STORAGE_KEY,
+                new CreateParticipantWithLocationRequest.LocationInput(
+                        new BigDecimal("37.5665"),
+                        new BigDecimal("126.9780"),
+                        "서울시 중구 명동"
+                )
+        );
+
+        when(meetingRepository.findById(MEETING_ID)).thenReturn(Optional.of(meeting));
+        when(participantRepository.existsByMeetingAndLocalStorageKey(meeting, LOCAL_STORAGE_KEY)).thenReturn(false);
+        when(locationPollRepository.findByMeeting(meeting)).thenReturn(Optional.of(locationPoll));
+
+        CreateParticipantResponse response = participantService.createWithLocation(MEETING_ID, request);
+
+        assertThat(response.name()).isEqualTo(request.name());
+        assertThat(response.hasLocation()).isTrue();
+        assertThat(response.scheduleVoteCount()).isNull();
+
+        ArgumentCaptor<Participant> captor = ArgumentCaptor.forClass(Participant.class);
+        verify(participantRepository).save(captor.capture());
+        Participant savedParticipant = captor.getValue();
+        assertThat(savedParticipant.getLocationVotes()).hasSize(1);
+        assertThat(savedParticipant.getLocationVotes().get(0).getLocationPoll()).isEqualTo(locationPoll);
+        assertThat(savedParticipant.getLocationVotes().get(0).getDepartureLat()).isEqualTo(request.location().latitude());
+        assertThat(savedParticipant.getLocationVotes().get(0).getDepartureLng()).isEqualTo(request.location().longitude());
+        assertThat(savedParticipant.getLocationVotes().get(0).getDepartureLocation()).isEqualTo(request.location().address());
+    }
+
+    @Test
+    @DisplayName("위치 투표 기반 참여자 생성 시 localStorageKey 중복이면 예외를 던진다")
+    void createWithLocation_duplicateLocalStorageKey() {
+        Meeting meeting = Meeting.of(10);
+        CreateParticipantWithLocationRequest request = new CreateParticipantWithLocationRequest(
+                "이영희",
+                LOCAL_STORAGE_KEY,
+                new CreateParticipantWithLocationRequest.LocationInput(
+                        new BigDecimal("37.5665"),
+                        new BigDecimal("126.9780"),
+                        "서울시 중구 명동"
+                )
+        );
+
+        when(meetingRepository.findById(MEETING_ID)).thenReturn(Optional.of(meeting));
+        when(participantRepository.existsByMeetingAndLocalStorageKey(meeting, LOCAL_STORAGE_KEY)).thenReturn(true);
+
+        assertThatThrownBy(() -> participantService.createWithLocation(MEETING_ID, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DUPLICATE_LOCAL_STORAGE_KEY);
+    }
+
+    @Test
+    @DisplayName("위치 투표 기반 참여자 생성 시 위치 투표판이 없으면 예외를 던진다")
+    void createWithLocation_locationPollNotFound() {
+        Meeting meeting = Meeting.of(10);
+        CreateParticipantWithLocationRequest request = new CreateParticipantWithLocationRequest(
+                "이영희",
+                LOCAL_STORAGE_KEY,
+                new CreateParticipantWithLocationRequest.LocationInput(
+                        new BigDecimal("37.5665"),
+                        new BigDecimal("126.9780"),
+                        "서울시 중구 명동"
+                )
+        );
+
+        when(meetingRepository.findById(MEETING_ID)).thenReturn(Optional.of(meeting));
+        when(participantRepository.existsByMeetingAndLocalStorageKey(meeting, LOCAL_STORAGE_KEY)).thenReturn(false);
+        when(locationPollRepository.findByMeeting(meeting)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> participantService.createWithLocation(MEETING_ID, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.LOCATION_POLL_NOT_FOUND);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -12,6 +12,11 @@ spring:
     properties:
       hibernate:
         format_sql: true
+    defer-datasource-initialization: true
+
+  sql:
+    init:
+      mode: never
 
 kakao:
   api:


### PR DESCRIPTION
## Issue Number
closed #6 #50 #51

## As-Is
- 참여자 일정/위치 투표를 동시에 받는 API가 없어 프런트에서 생성 요청을 보낼 수 없고, localStorageKey 중복 검증/응답 스펙도 정의되어 있지 않았습니다.
- Meeting 도메인은 fetch join/삭제 기능이 부족해 전체 모임 조회나 모임 삭제 시 연관 엔티티 정리가 어려웠고, 서비스 단위 테스트/통합 테스트가 없어 회귀 위험이 컸습니다.
- 로컬에서 바로 띄울 수 있는 MySQL 컨테이너와 설정 가이드, seed 데이터가 없어 온보딩 속도가 느렸고 `application-local.yml`이 아직 환경변수 의존이었습니다.
- 최적 장소 테스트 API는 Swagger 스펙이 빈약해 요청/응답을 한눈에 확인하기 어려웠습니다.

## To-Be
- `ParticipantController`에 일정/위치 투표 기반 생성 엔드포인트를 추가하고(`…/schedule`, `…/location`), Service/Repository/DTO를 통해 유효성 검증, 중복 방지, 투표 엔티티 생성, 응답 DTO를 모두 구성했습니다.
- `MeetingService`에 모임 전체 조회/삭제 기능을 추가하고 Repository fetch join 쿼리를 확장했으며, 에러 코드(`SCHEDULE_POLL_NOT_FOUND`, `LOCATION_POLL_NOT_FOUND`, `DUPLICATE_LOCAL_STORAGE_KEY`)를 정의해 예외 상황을 명확히 했습니다.
- Participant/Meeting 서비스·컨트롤러 단위 테스트와 `MeetingServiceIntegrationTest`를 새로 추가하고, `spring-boot-starter-test` 의존성과 seed 데이터를 활용해 도메인 전반을 검증했습니다.
- 로컬 개발을 위한 `docker-compose.yml`, `docs/local-dev-setup.md`, `application-local.yml` 고정 값, `data.sql` 시드 데이터를 추가해 컨테이너 실행만으로 즉시 개발/테스트가 가능하도록 했습니다.
- `OptimalLocationController` 및 요청/응답 DTO에 Swagger 메타데이터와 예시 payload/response를 추가해 테스트용 API 사용성을 높였습니다.

## Diagram
```mermaid
sequenceDiagram
    participant FE as Frontend
    participant PC as ParticipantController
    participant PS as ParticipantService
    participant MR as MeetingRepository
    participant SPR as SchedulePollRepository
    participant LPR as LocationPollRepository
    participant PR as ParticipantRepository

    FE->>+PC: POST /api/meetings/{id}/participants/{mode}
    PC->>+PS: createWithSchedule/createWithLocation()
    PS->>+MR: findById(meetingId)
    MR-->>-PS: Meeting
    PS->>PR: existsByMeetingAndLocalStorageKey()
    alt 일정 투표
        PS->>+SPR: findByMeeting()
        SPR-->>-PS: SchedulePoll
        PS->>PR: save(Participant + ScheduleVotes)
    else 위치 투표
        PS->>+LPR: findByMeeting()
        LPR-->>-PS: LocationPoll
        PS->>PR: save(Participant + LocationVote)
    end
    PS-->>-PC: CreateParticipantResponse
    PC-->>-FE: ApiResponse(S100/S101)
```


```mermaid
graph LR
    subgraph Web Layer
        MC[MeetingController]
        PC[ParticipantController]
        OLC[OptimalLocationController 테스트]
    end

    subgraph Service Layer
        MS[(MeetingServiceImpl)]
        PS[(ParticipantServiceImpl)]
        OLS[(OptimalLocationService)]
    end

    subgraph Persistence Layer
        MR[(MeetingRepository)]
        PR[(ParticipantRepository)]
        SPR[(SchedulePollRepository)]
        LPR[(LocationPollRepository)]
    end

    subgraph Infra & Docs
        DCompose[docker-compose.yml<br/>MySQL]
        ALocal[application-local.yml]
        DataSQL[data.sql]
        DocGuide[docs/local-dev-setup.md]
    end

    MC --> MS
    PC --> PS
    OLC --> OLS
    MS --> MR
    MS --> SPR
    MS --> LPR
    PS --> MR
    PS --> SPR
    PS --> LPR
    PS --> PR
    OLS --> Kakao[(KakaoLocalClient)]
    OLS --> Odsay[(OdsayClient)]
    DCompose --> ALocal
    ALocal --> DataSQL
    DocGuide --> DCompose
```

## Review Request (중요)
- 코드 리뷰는 **한국어로 작성**해주세요.
- 구현 의도, 리스크, 개선 포인트 중심으로 리뷰 부탁드립니다.

## Check List
- [ ] 테스트가 전부 통과되었나요? (로컬 `./gradlew test` 실행 시 H2에서 `data.sql`을 적용할 테이블이 없어 `Table "MEETING" not found` 에러로 실패)
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
- 테스트 데이터 삽입 순서를 조정하거나 test profile에서 `data.sql` 실행을 분리하지 않으면 CI에서도 동일한 오류가 발생할 수 있습니다.
- 시퀀스/구조 다이어그램은 신규 참가자 생성 플로우와 전체 계층 구조를 묘사하므로 리뷰 시 참고 부탁드립니다.
