### PR TITLE
refactor (meeting) : 모임 조회 API을 기존 쿼리 두개로 분리하여 사용 -> 하나로 통합 사용

### DIFF
--- a/src/main/java/com/dnd/moyeolak/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/dnd/moyeolak/domain/meeting/repository/MeetingRepository.java
@@ -12,21 +12,6 @@ public interface MeetingRepository extends JpaRepository<Meeting, String> {
 
     @Query("""
         SELECT m FROM Meeting m
-        LEFT JOIN FETCH m.participants
-        WHERE m.meetingId = :meetingId
-    """)
-    Optional<Meeting> findByIdWithParticipants(@Param("meetingId") String meetingId);
-
-    @Query("""
-        SELECT m FROM Meeting m
-        LEFT JOIN FETCH m.schedulePoll sp
-        LEFT JOIN FETCH sp.scheduleVotes
-        WHERE m.meetingId = :meetingId
-    """)
-    Optional<Meeting> findByIdWithScheduleVotes(@Param("meetingId") String meetingId);
-
-    @Query("""
-        SELECT m FROM Meeting m
         LEFT JOIN FETCH m.schedulePoll
         LEFT JOIN FETCH m.locationPoll
         LEFT JOIN FETCH m.participants

--- a/src/main/java/com/dnd/moyeolak/domain/meeting/service/impl/MeetingServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/meeting/service/impl/MeetingServiceImpl.java
@@ -38,10 +38,7 @@ public class MeetingServiceImpl implements MeetingService {
 
     @Override
     public GetMeetingScheduleResponse getMeetingSchedules(String meetingId) {
-        meetingRepository.findByIdWithParticipants(meetingId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));
-
-        Meeting meeting = meetingRepository.findByIdWithScheduleVotes(meetingId)
+        Meeting meeting = meetingRepository.findByIdWithAllAssociations(meetingId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));
 
         return GetMeetingScheduleResponse.from(meeting);

--- a/src/test/java/com/dnd/moyeolak/domain/meeting/service/MeetingServiceUnitTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/meeting/service/MeetingServiceUnitTest.java
@@ -47,8 +47,7 @@ class MeetingServiceUnitTest {
         // given
         String meetingId = "test-meeting-id";
         Meeting meeting = createMeetingWithAllAssociations();
-        when(meetingRepository.findByIdWithParticipants(meetingId)).thenReturn(Optional.of(meeting));
-        when(meetingRepository.findByIdWithScheduleVotes(meetingId)).thenReturn(Optional.of(meeting));
+        when(meetingRepository.findByIdWithAllAssociations(meetingId)).thenReturn(Optional.of(meeting));
 
         // when
         GetMeetingScheduleResponse response = meetingService.getMeetingSchedules(meetingId);
@@ -63,8 +62,7 @@ class MeetingServiceUnitTest {
         // given
         String meetingId = "test-meeting-id";
         Meeting meeting = createMeetingWithAllAssociations();
-        when(meetingRepository.findByIdWithParticipants(meetingId)).thenReturn(Optional.of(meeting));
-        when(meetingRepository.findByIdWithScheduleVotes(meetingId)).thenReturn(Optional.of(meeting));
+        when(meetingRepository.findByIdWithAllAssociations(meetingId)).thenReturn(Optional.of(meeting));
 
         // when
         GetMeetingScheduleResponse response = meetingService.getMeetingSchedules(meetingId);
@@ -81,8 +79,7 @@ class MeetingServiceUnitTest {
         // given
         String meetingId = "test-meeting-id";
         Meeting meeting = createMeetingWithAllAssociations();
-        when(meetingRepository.findByIdWithParticipants(meetingId)).thenReturn(Optional.of(meeting));
-        when(meetingRepository.findByIdWithScheduleVotes(meetingId)).thenReturn(Optional.of(meeting));
+        when(meetingRepository.findByIdWithAllAssociations(meetingId)).thenReturn(Optional.of(meeting));
 
         // when
         GetMeetingScheduleResponse response = meetingService.getMeetingSchedules(meetingId);
@@ -99,8 +96,7 @@ class MeetingServiceUnitTest {
         // given
         String meetingId = "test-meeting-id";
         Meeting meeting = createMeetingWithAllAssociations();
-        when(meetingRepository.findByIdWithParticipants(meetingId)).thenReturn(Optional.of(meeting));
-        when(meetingRepository.findByIdWithScheduleVotes(meetingId)).thenReturn(Optional.of(meeting));
+        when(meetingRepository.findByIdWithAllAssociations(meetingId)).thenReturn(Optional.of(meeting));
 
         // when
         GetMeetingScheduleResponse response = meetingService.getMeetingSchedules(meetingId);
@@ -116,7 +112,7 @@ class MeetingServiceUnitTest {
     void getMeetingSchedules_throwsExceptionWhenNotFound() {
         // given
         String meetingId = "non-existent-id";
-        when(meetingRepository.findByIdWithParticipants(meetingId)).thenReturn(Optional.empty());
+        when(meetingRepository.findByIdWithAllAssociations(meetingId)).thenReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> meetingService.getMeetingSchedules(meetingId))
@@ -130,8 +126,7 @@ class MeetingServiceUnitTest {
         // given
         String meetingId = "test-meeting-id";
         Meeting meeting = createMeetingWithAllAssociations();
-        when(meetingRepository.findByIdWithParticipants(meetingId)).thenReturn(Optional.of(meeting));
-        when(meetingRepository.findByIdWithScheduleVotes(meetingId)).thenReturn(Optional.of(meeting));
+        when(meetingRepository.findByIdWithAllAssociations(meetingId)).thenReturn(Optional.of(meeting));
 
         // when
         GetMeetingScheduleResponse response = meetingService.getMeetingSchedules(meetingId);


### PR DESCRIPTION
## Issue Number
closed #이슈넘버

## As-Is
<!-- 문제 상황 정의 -->
- 기존 JPQL 의 MultipleBagFetchExcetpion 문제 및 N+1 문제로 인해 쿼리를 분리하여 2개의 쿼리를 호출해서 Meeting 정보를 조회했음.

## To-Be
<!-- 변경 사항 -->
- 모임 조회 API을 기존 쿼리 두개로 분리하여 사용하는 방법에서 findByIdWithAllAssociations() 하나로 연관관계 매핑하여 조회하도록 수정
- 이전 커밋(PR) 에서 @BatchSize 를 통해 위 문제를 해결하였음.
- 관련하여 단위/통합 테스트 코드 수정

## Review Request (중요)
- 코드 리뷰는 **한국어로 작성**해주세요.
- 구현 의도, 리스크, 개선 포인트 중심으로 리뷰 부탁드립니다.

## Check List
- [v] 테스트가 전부 통과되었나요?
- [v] 모든 commit이 push 되었나요?
- [v] merge할 branch를 확인했나요?
- [ ] Assignee를 지정했나요?
- [v] Label을 지정했나요?
- [ ] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
