### PR TITLE
refactor (participant) : Facade 패턴 적용 및 도메인 경계 분리

### DIFF
--- a/src/main/java/com/dnd/moyeolak/domain/location/service/LocationVoteService.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/service/LocationVoteService.java
@@ -1,0 +1,12 @@
+package com.dnd.moyeolak.domain.location.service;
+
+import com.dnd.moyeolak.domain.location.entity.LocationVote;
+import com.dnd.moyeolak.domain.meeting.entity.Meeting;
+import com.dnd.moyeolak.domain.participant.entity.Participant;
+
+import java.math.BigDecimal;
+
+public interface LocationVoteService {
+
+    LocationVote createVote(Meeting meeting, Participant participant, String address, BigDecimal latitude, BigDecimal longitude);
+}

--- a/src/main/java/com/dnd/moyeolak/domain/location/service/impl/LocationVoteServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/service/impl/LocationVoteServiceImpl.java
@@ -1,0 +1,33 @@
+package com.dnd.moyeolak.domain.location.service.impl;
+
+import com.dnd.moyeolak.domain.location.entity.LocationPoll;
+import com.dnd.moyeolak.domain.location.entity.LocationVote;
+import com.dnd.moyeolak.domain.location.repository.LocationPollRepository;
+import com.dnd.moyeolak.domain.location.service.LocationVoteService;
+import com.dnd.moyeolak.domain.meeting.entity.Meeting;
+import com.dnd.moyeolak.domain.participant.entity.Participant;
+import com.dnd.moyeolak.global.exception.BusinessException;
+import com.dnd.moyeolak.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LocationVoteServiceImpl implements LocationVoteService {
+
+    private final LocationPollRepository locationPollRepository;
+
+    @Override
+    @Transactional
+    public LocationVote createVote(Meeting meeting, Participant participant,
+                                   String address, BigDecimal latitude, BigDecimal longitude) {
+        LocationPoll locationPoll = locationPollRepository.findByMeeting(meeting)
+                .orElseThrow(() -> new BusinessException(ErrorCode.LOCATION_POLL_NOT_FOUND));
+
+        return LocationVote.of(locationPoll, participant, address, latitude, longitude);
+    }
+}

--- a/src/main/java/com/dnd/moyeolak/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/dnd/moyeolak/domain/meeting/service/MeetingService.java
@@ -2,12 +2,15 @@ package com.dnd.moyeolak.domain.meeting.service;
 
 import com.dnd.moyeolak.domain.meeting.dto.CreateMeetingRequest;
 import com.dnd.moyeolak.domain.meeting.dto.GetMeetingScheduleResponse;
+import com.dnd.moyeolak.domain.meeting.entity.Meeting;
 
 import java.util.List;
 
 public interface MeetingService {
 
     String createMeeting(CreateMeetingRequest request);
+
+    Meeting get(String meetingId);
 
     GetMeetingScheduleResponse getMeetingSchedules(String meetingId);
 

--- a/src/main/java/com/dnd/moyeolak/domain/meeting/service/impl/MeetingServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/meeting/service/impl/MeetingServiceImpl.java
@@ -37,6 +37,12 @@ public class MeetingServiceImpl implements MeetingService {
     }
 
     @Override
+    public Meeting get(String meetingId) {
+        return meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));
+    }
+
+    @Override
     public GetMeetingScheduleResponse getMeetingSchedules(String meetingId) {
         Meeting meeting = meetingRepository.findByIdWithAllAssociations(meetingId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));

--- a/src/main/java/com/dnd/moyeolak/domain/participant/controller/ParticipantController.java
+++ b/src/main/java/com/dnd/moyeolak/domain/participant/controller/ParticipantController.java
@@ -3,10 +3,15 @@ package com.dnd.moyeolak.domain.participant.controller;
 import com.dnd.moyeolak.domain.participant.dto.CreateParticipantResponse;
 import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithLocationRequest;
 import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithScheduleRequest;
-import com.dnd.moyeolak.domain.participant.service.ParticipantService;
+import com.dnd.moyeolak.domain.participant.facade.ParticipantFacade;
 import com.dnd.moyeolak.global.response.ApiResponse;
 import com.dnd.moyeolak.global.response.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -16,32 +21,231 @@ import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Participant", description = "참여자 관련 API")
 @RestController
-@RequestMapping("/api/meetings/{meetingId}/participants")
+@RequestMapping("/api/participants")
 @RequiredArgsConstructor
 public class ParticipantController {
 
-    private final ParticipantService participantService;
+    private final ParticipantFacade participantFacade;
 
-    @PostMapping("/schedule")
-    @Operation(summary = "일정 기반 참여자 생성", description = "참여자와 가능한 시간대 투표를 함께 생성합니다.")
-    public ResponseEntity<ApiResponse<CreateParticipantResponse>> createWithSchedule(
-            @PathVariable String meetingId,
+    @PostMapping("/join-with-schedule")
+    @Operation(
+            summary = "일정 투표와 함께 참여",
+            description = """
+                    참여자 생성과 동시에 가능한 시간대에 투표합니다.
+
+                    ### 사용 시점
+                    - 모임 생성자가 일정 투표를 시작한 후
+                    - 참여자가 자신의 가능한 시간대를 선택할 때
+
+                    ### 주의사항
+                    - `availableSchedules`는 30분 단위로 전송 (예: 09:00, 09:30, 10:00)
+                    - 시간은 ISO-8601 형식 + Asia/Seoul 기준
+                    - `localStorageKey`는 브라우저별 고유값 (재참여 방지용)
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "201",
+                    description = "참여자 생성 및 일정 투표 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CreateParticipantResponse.class),
+                            examples = @ExampleObject(
+                                    name = "성공 응답",
+                                    summary = "일정 투표 참여 성공",
+                                    value = """
+                                            {
+                                              "code": "S101",
+                                              "message": "리소스가 성공적으로 생성되었습니다.",
+                                              "data": {
+                                                "participantId": 15,
+                                                "name": "김철수",
+                                                "scheduleVoteCount": 4,
+                                                "hasLocation": false,
+                                                "createdAt": "2025-02-06T14:30:00"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "요청 데이터 검증 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "필수값 누락",
+                                            summary = "이름 미입력",
+                                            value = """
+                                                    {
+                                                      "code": "E103",
+                                                      "message": "유효성 검증 실패",
+                                                      "data": {
+                                                        "name": "이름은 필수입니다"
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "빈 일정 목록",
+                                            summary = "가능한 시간 미선택",
+                                            value = """
+                                                    {
+                                                      "code": "E103",
+                                                      "message": "유효성 검증 실패",
+                                                      "data": {
+                                                        "availableSchedules": "가능한 시간 정보는 필수입니다"
+                                                      }
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "모임을 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "모임 없음",
+                                    value = """
+                                            {
+                                              "code": "E410",
+                                              "message": "모임이 존재하지 않습니다."
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    public ResponseEntity<ApiResponse<CreateParticipantResponse>> joinWithSchedule(
+            @Parameter(
+                    description = "참여할 모임 ID",
+                    example = "abc123",
+                    required = true
+            )
+            @RequestParam String meetingId,
             @Valid @RequestBody CreateParticipantWithScheduleRequest request) {
 
-        CreateParticipantResponse response = participantService.createWithSchedule(meetingId, request);
+        CreateParticipantResponse response = participantFacade.createWithSchedule(meetingId, request);
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.success(SuccessCode.RESOURCE_CREATED, response));
     }
 
-    @PostMapping("/location")
-    @Operation(summary = "위치 기반 참여자 생성", description = "참여자와 출발지 위치 투표를 함께 생성합니다.")
-    public ResponseEntity<ApiResponse<CreateParticipantResponse>> createWithLocation(
-            @PathVariable String meetingId,
+    @PostMapping("/join-with-location")
+    @Operation(
+            summary = "위치 투표와 함께 참여",
+            description = """
+                    참여자 생성과 동시에 출발지 위치를 등록합니다.
+
+                    ### 사용 시점
+                    - 일정이 확정된 후, 모임 장소를 정할 때
+                    - 참여자가 자신의 출발 위치를 입력할 때
+
+                    ### 좌표 입력 방법
+                    - 프론트에서 Kakao/Google Maps API로 좌표 획득
+                    - 위도(latitude): -90 ~ 90
+                    - 경도(longitude): -180 ~ 180
+                    - 주소(address): 선택 입력 (사용자 확인용)
+
+                    ### 예시 좌표
+                    - 서울역: 위도 37.5547, 경도 126.9707
+                    - 강남역: 위도 37.4979, 경도 127.0276
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "201",
+                    description = "참여자 생성 및 위치 등록 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CreateParticipantResponse.class),
+                            examples = @ExampleObject(
+                                    name = "성공 응답",
+                                    summary = "위치 투표 참여 성공",
+                                    value = """
+                                            {
+                                              "code": "S101",
+                                              "message": "리소스가 성공적으로 생성되었습니다.",
+                                              "data": {
+                                                "participantId": 16,
+                                                "name": "이영희",
+                                                "scheduleVoteCount": null,
+                                                "hasLocation": true,
+                                                "createdAt": "2025-02-06T14:35:00"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "요청 데이터 검증 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "좌표 범위 초과",
+                                            summary = "위도가 90 초과",
+                                            value = """
+                                                    {
+                                                      "code": "E103",
+                                                      "message": "유효성 검증 실패",
+                                                      "data": {
+                                                        "location.latitude": "위도는 90 이하여야 합니다"
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "위치 정보 누락",
+                                            summary = "location 객체 미전송",
+                                            value = """
+                                                    {
+                                                      "code": "E103",
+                                                      "message": "유효성 검증 실패",
+                                                      "data": {
+                                                        "location": "위치 정보는 필수입니다"
+                                                      }
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "모임을 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "모임 없음",
+                                    value = """
+                                            {
+                                              "code": "E410",
+                                              "message": "모임이 존재하지 않습니다."
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    public ResponseEntity<ApiResponse<CreateParticipantResponse>> joinWithLocation(
+            @Parameter(
+                    description = "참여할 모임 ID",
+                    example = "abc123",
+                    required = true
+            )
+            @RequestParam String meetingId,
             @Valid @RequestBody CreateParticipantWithLocationRequest request) {
 
-        CreateParticipantResponse response = participantService.createWithLocation(meetingId, request);
+        CreateParticipantResponse response = participantFacade.createWithLocation(meetingId, request);
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)

--- a/src/main/java/com/dnd/moyeolak/domain/participant/facade/ParticipantFacade.java
+++ b/src/main/java/com/dnd/moyeolak/domain/participant/facade/ParticipantFacade.java
@@ -1,0 +1,66 @@
+package com.dnd.moyeolak.domain.participant.facade;
+
+import com.dnd.moyeolak.domain.location.entity.LocationVote;
+import com.dnd.moyeolak.domain.location.service.LocationVoteService;
+import com.dnd.moyeolak.domain.meeting.entity.Meeting;
+import com.dnd.moyeolak.domain.meeting.service.MeetingService;
+import com.dnd.moyeolak.domain.participant.dto.CreateParticipantResponse;
+import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithLocationRequest;
+import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithScheduleRequest;
+import com.dnd.moyeolak.domain.participant.entity.Participant;
+import com.dnd.moyeolak.domain.participant.service.ParticipantService;
+import com.dnd.moyeolak.domain.schedule.entity.ScheduleVote;
+import com.dnd.moyeolak.domain.schedule.service.ScheduleVoteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ParticipantFacade {
+
+    private final MeetingService meetingService;
+    private final ParticipantService participantService;
+    private final ScheduleVoteService scheduleVoteService;
+    private final LocationVoteService locationVoteService;
+
+    @Transactional
+    public CreateParticipantResponse createWithSchedule(String meetingId, CreateParticipantWithScheduleRequest request) {
+        Meeting meeting = meetingService.get(meetingId);
+
+        participantService.validateLocalStorageKeyUnique(meeting, request.localStorageKey());
+
+        Participant participant = participantService.create(meeting, request.name(), request.localStorageKey());
+
+        List<ScheduleVote> scheduleVotes = scheduleVoteService.createVotes(
+                meeting,
+                participant,
+                request.availableSchedules()
+        );
+        participant.getScheduleVotes().addAll(scheduleVotes);
+
+        return CreateParticipantResponse.fromSchedule(participant, scheduleVotes.size());
+    }
+
+    @Transactional
+    public CreateParticipantResponse createWithLocation(String meetingId, CreateParticipantWithLocationRequest request) {
+        Meeting meeting = meetingService.get(meetingId);
+
+        participantService.validateLocalStorageKeyUnique(meeting, request.localStorageKey());
+
+        Participant participant = participantService.create(meeting, request.name(), request.localStorageKey());
+
+        LocationVote locationVote = locationVoteService.createVote(
+                meeting,
+                participant,
+                request.location().address(),
+                request.location().latitude(),
+                request.location().longitude()
+        );
+        participant.getLocationVotes().add(locationVote);
+
+        return CreateParticipantResponse.fromLocation(participant);
+    }
+}

--- a/src/main/java/com/dnd/moyeolak/domain/participant/service/ParticipantService.java
+++ b/src/main/java/com/dnd/moyeolak/domain/participant/service/ParticipantService.java
@@ -1,12 +1,11 @@
 package com.dnd.moyeolak.domain.participant.service;
 
-import com.dnd.moyeolak.domain.participant.dto.CreateParticipantResponse;
-import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithLocationRequest;
-import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithScheduleRequest;
+import com.dnd.moyeolak.domain.meeting.entity.Meeting;
+import com.dnd.moyeolak.domain.participant.entity.Participant;
 
 public interface ParticipantService {
 
-    CreateParticipantResponse createWithSchedule(String meetingId, CreateParticipantWithScheduleRequest request);
+    Participant create(Meeting meeting, String name, String localStorageKey);
 
-    CreateParticipantResponse createWithLocation(String meetingId, CreateParticipantWithLocationRequest request);
+    void validateLocalStorageKeyUnique(Meeting meeting, String localStorageKey);
 }

--- a/src/main/java/com/dnd/moyeolak/domain/participant/service/impl/ParticipantServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/participant/service/impl/ParticipantServiceImpl.java
@@ -1,101 +1,34 @@
 package com.dnd.moyeolak.domain.participant.service.impl;
 
-import com.dnd.moyeolak.domain.location.entity.LocationPoll;
-import com.dnd.moyeolak.domain.location.entity.LocationVote;
-import com.dnd.moyeolak.domain.location.repository.LocationPollRepository;
 import com.dnd.moyeolak.domain.meeting.entity.Meeting;
-import com.dnd.moyeolak.domain.meeting.repository.MeetingRepository;
-import com.dnd.moyeolak.domain.participant.dto.CreateParticipantResponse;
-import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithLocationRequest;
-import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithScheduleRequest;
 import com.dnd.moyeolak.domain.participant.entity.Participant;
 import com.dnd.moyeolak.domain.participant.repository.ParticipantRepository;
 import com.dnd.moyeolak.domain.participant.service.ParticipantService;
-import com.dnd.moyeolak.domain.schedule.entity.SchedulePoll;
-import com.dnd.moyeolak.domain.schedule.entity.ScheduleVote;
-import com.dnd.moyeolak.domain.schedule.repository.SchedulePollRepository;
 import com.dnd.moyeolak.global.exception.BusinessException;
 import com.dnd.moyeolak.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ParticipantServiceImpl implements ParticipantService {
 
-    private final MeetingRepository meetingRepository;
     private final ParticipantRepository participantRepository;
-    private final SchedulePollRepository schedulePollRepository;
-    private final LocationPollRepository locationPollRepository;
 
     @Override
     @Transactional
-    public CreateParticipantResponse createWithSchedule(String meetingId, CreateParticipantWithScheduleRequest request) {
-        Meeting meeting = findMeetingById(meetingId);
-
-        validateLocalStorageKeyUnique(meeting, request.localStorageKey());
-
-        SchedulePoll schedulePoll = schedulePollRepository.findByMeeting(meeting)
-                .orElseThrow(() -> new BusinessException(ErrorCode.SCHEDULE_POLL_NOT_FOUND));
-
-        Participant participant = Participant.of(meeting, request.localStorageKey(), request.name());
+    public Participant create(Meeting meeting, String name, String localStorageKey) {
+        Participant participant = Participant.of(meeting, localStorageKey, name);
         meeting.addParticipant(participant);
-
-        List<ScheduleVote> scheduleVotes = createScheduleVotes(participant, schedulePoll, request.availableSchedules());
-        participant.getScheduleVotes().addAll(scheduleVotes);
-
-        participantRepository.save(participant);
-
-        return CreateParticipantResponse.fromSchedule(participant, scheduleVotes.size());
+        return participantRepository.save(participant);
     }
 
     @Override
-    @Transactional
-    public CreateParticipantResponse createWithLocation(String meetingId, CreateParticipantWithLocationRequest request) {
-        Meeting meeting = findMeetingById(meetingId);
-
-        validateLocalStorageKeyUnique(meeting, request.localStorageKey());
-
-        LocationPoll locationPoll = locationPollRepository.findByMeeting(meeting)
-                .orElseThrow(() -> new BusinessException(ErrorCode.LOCATION_POLL_NOT_FOUND));
-
-        Participant participant = Participant.of(meeting, request.localStorageKey(), request.name());
-        meeting.addParticipant(participant);
-
-        LocationVote locationVote = LocationVote.of(
-                locationPoll,
-                participant,
-                request.location().address(),
-                request.location().latitude(),
-                request.location().longitude()
-        );
-        participant.getLocationVotes().add(locationVote);
-
-        participantRepository.save(participant);
-
-        return CreateParticipantResponse.fromLocation(participant);
-    }
-
-    private Meeting findMeetingById(String meetingId) {
-        return meetingRepository.findById(meetingId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));
-    }
-
-    private void validateLocalStorageKeyUnique(Meeting meeting, String localStorageKey) {
+    public void validateLocalStorageKeyUnique(Meeting meeting, String localStorageKey) {
         if (participantRepository.existsByMeetingAndLocalStorageKey(meeting, localStorageKey)) {
             throw new BusinessException(ErrorCode.DUPLICATE_LOCAL_STORAGE_KEY);
         }
-    }
-
-    private List<ScheduleVote> createScheduleVotes(Participant participant, SchedulePoll schedulePoll,
-                                                   List<LocalDateTime> availableSchedules) {
-        return availableSchedules.stream()
-                .map(schedule -> ScheduleVote.of(participant, schedulePoll, schedule))
-                .toList();
     }
 }

--- a/src/main/java/com/dnd/moyeolak/domain/schedule/service/ScheduleVoteService.java
+++ b/src/main/java/com/dnd/moyeolak/domain/schedule/service/ScheduleVoteService.java
@@ -1,0 +1,13 @@
+package com.dnd.moyeolak.domain.schedule.service;
+
+import com.dnd.moyeolak.domain.meeting.entity.Meeting;
+import com.dnd.moyeolak.domain.participant.entity.Participant;
+import com.dnd.moyeolak.domain.schedule.entity.ScheduleVote;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ScheduleVoteService {
+
+    List<ScheduleVote> createVotes(Meeting meeting, Participant participant, List<LocalDateTime> availableSchedules);
+}

--- a/src/main/java/com/dnd/moyeolak/domain/schedule/service/impl/ScheduleVoteServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/schedule/service/impl/ScheduleVoteServiceImpl.java
@@ -1,0 +1,35 @@
+package com.dnd.moyeolak.domain.schedule.service.impl;
+
+import com.dnd.moyeolak.domain.meeting.entity.Meeting;
+import com.dnd.moyeolak.domain.participant.entity.Participant;
+import com.dnd.moyeolak.domain.schedule.entity.SchedulePoll;
+import com.dnd.moyeolak.domain.schedule.entity.ScheduleVote;
+import com.dnd.moyeolak.domain.schedule.repository.SchedulePollRepository;
+import com.dnd.moyeolak.domain.schedule.service.ScheduleVoteService;
+import com.dnd.moyeolak.global.exception.BusinessException;
+import com.dnd.moyeolak.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ScheduleVoteServiceImpl implements ScheduleVoteService {
+
+    private final SchedulePollRepository schedulePollRepository;
+
+    @Override
+    @Transactional
+    public List<ScheduleVote> createVotes(Meeting meeting, Participant participant, List<LocalDateTime> availableSchedules) {
+        SchedulePoll schedulePoll = schedulePollRepository.findByMeeting(meeting)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SCHEDULE_POLL_NOT_FOUND));
+
+        return availableSchedules.stream()
+                .map(schedule -> ScheduleVote.of(participant, schedulePoll, schedule))
+                .toList();
+    }
+}

--- a/src/test/java/com/dnd/moyeolak/domain/location/service/LocationVoteServiceImplTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/location/service/LocationVoteServiceImplTest.java
@@ -1,0 +1,69 @@
+package com.dnd.moyeolak.domain.location.service;
+
+import com.dnd.moyeolak.domain.location.entity.LocationPoll;
+import com.dnd.moyeolak.domain.location.entity.LocationVote;
+import com.dnd.moyeolak.domain.location.repository.LocationPollRepository;
+import com.dnd.moyeolak.domain.location.service.impl.LocationVoteServiceImpl;
+import com.dnd.moyeolak.domain.meeting.entity.Meeting;
+import com.dnd.moyeolak.domain.participant.entity.Participant;
+import com.dnd.moyeolak.global.exception.BusinessException;
+import com.dnd.moyeolak.global.response.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LocationVoteServiceImplTest {
+
+    @Mock
+    private LocationPollRepository locationPollRepository;
+
+    @InjectMocks
+    private LocationVoteServiceImpl locationVoteService;
+
+    @Test
+    @DisplayName("위치 투표 생성 성공 시 투표를 반환한다")
+    void createVote_success() {
+        Meeting meeting = Meeting.of(10);
+        LocationPoll locationPoll = LocationPoll.defaultOf(meeting);
+        Participant participant = Participant.of(meeting, "local-key", "홍길동");
+        String address = "서울시 중구 명동";
+        BigDecimal latitude = new BigDecimal("37.5665");
+        BigDecimal longitude = new BigDecimal("126.9780");
+
+        when(locationPollRepository.findByMeeting(meeting)).thenReturn(Optional.of(locationPoll));
+
+        LocationVote result = locationVoteService.createVote(meeting, participant, address, latitude, longitude);
+
+        assertThat(result.getParticipant()).isEqualTo(participant);
+        assertThat(result.getLocationPoll()).isEqualTo(locationPoll);
+        assertThat(result.getDepartureLocation()).isEqualTo(address);
+        assertThat(result.getDepartureLat()).isEqualTo(latitude);
+        assertThat(result.getDepartureLng()).isEqualTo(longitude);
+    }
+
+    @Test
+    @DisplayName("위치 투표판이 없으면 예외를 던진다")
+    void createVote_throwsExceptionWhenLocationPollNotFound() {
+        Meeting meeting = Meeting.of(10);
+        Participant participant = Participant.of(meeting, "local-key", "홍길동");
+
+        when(locationPollRepository.findByMeeting(meeting)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> locationVoteService.createVote(
+                meeting, participant, "서울시 중구", new BigDecimal("37.5665"), new BigDecimal("126.9780")))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.LOCATION_POLL_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/dnd/moyeolak/domain/participant/facade/ParticipantFacadeTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/participant/facade/ParticipantFacadeTest.java
@@ -1,0 +1,250 @@
+package com.dnd.moyeolak.domain.participant.facade;
+
+import com.dnd.moyeolak.domain.location.entity.LocationPoll;
+import com.dnd.moyeolak.domain.location.entity.LocationVote;
+import com.dnd.moyeolak.domain.location.service.LocationVoteService;
+import com.dnd.moyeolak.domain.meeting.entity.Meeting;
+import com.dnd.moyeolak.domain.meeting.service.MeetingService;
+import com.dnd.moyeolak.domain.participant.dto.CreateParticipantResponse;
+import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithLocationRequest;
+import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithScheduleRequest;
+import com.dnd.moyeolak.domain.participant.entity.Participant;
+import com.dnd.moyeolak.domain.participant.service.ParticipantService;
+import com.dnd.moyeolak.domain.schedule.entity.SchedulePoll;
+import com.dnd.moyeolak.domain.schedule.entity.ScheduleVote;
+import com.dnd.moyeolak.domain.schedule.service.ScheduleVoteService;
+import com.dnd.moyeolak.global.exception.BusinessException;
+import com.dnd.moyeolak.global.response.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ParticipantFacadeTest {
+
+    private static final String MEETING_ID = "meeting-id";
+    private static final String LOCAL_STORAGE_KEY = "local-storage-key";
+
+    @Mock
+    private MeetingService meetingService;
+
+    @Mock
+    private ParticipantService participantService;
+
+    @Mock
+    private ScheduleVoteService scheduleVoteService;
+
+    @Mock
+    private LocationVoteService locationVoteService;
+
+    @InjectMocks
+    private ParticipantFacade participantFacade;
+
+    @Test
+    @DisplayName("일정 투표 기반 참여자 생성 성공 시 투표 개수와 저장 여부를 반환한다")
+    void createWithSchedule_success() {
+        Meeting meeting = Meeting.of(10);
+        SchedulePoll schedulePoll = SchedulePoll.defaultOf(meeting);
+        Participant participant = Participant.of(meeting, LOCAL_STORAGE_KEY, "홍길동");
+        List<LocalDateTime> schedules = List.of(
+                LocalDateTime.of(2025, 2, 10, 9, 0),
+                LocalDateTime.of(2025, 2, 10, 10, 0)
+        );
+        CreateParticipantWithScheduleRequest request = new CreateParticipantWithScheduleRequest(
+                "홍길동",
+                LOCAL_STORAGE_KEY,
+                schedules
+        );
+        List<ScheduleVote> scheduleVotes = schedules.stream()
+                .map(s -> ScheduleVote.of(participant, schedulePoll, s))
+                .toList();
+
+        when(meetingService.get(MEETING_ID)).thenReturn(meeting);
+        when(participantService.create(meeting, request.name(), request.localStorageKey())).thenReturn(participant);
+        when(scheduleVoteService.createVotes(meeting, participant, schedules)).thenReturn(scheduleVotes);
+
+        CreateParticipantResponse response = participantFacade.createWithSchedule(MEETING_ID, request);
+
+        assertThat(response.name()).isEqualTo(request.name());
+        assertThat(response.scheduleVoteCount()).isEqualTo(request.availableSchedules().size());
+        assertThat(response.hasLocation()).isFalse();
+
+        verify(participantService).validateLocalStorageKeyUnique(meeting, LOCAL_STORAGE_KEY);
+        verify(participantService).create(meeting, request.name(), request.localStorageKey());
+        verify(scheduleVoteService).createVotes(meeting, participant, schedules);
+    }
+
+    @Test
+    @DisplayName("일정 투표 기반 참여자 생성 시 모임을 찾지 못하면 예외를 던진다")
+    void createWithSchedule_meetingNotFound() {
+        CreateParticipantWithScheduleRequest request = new CreateParticipantWithScheduleRequest(
+                "홍길동",
+                LOCAL_STORAGE_KEY,
+                List.of(LocalDateTime.of(2025, 2, 10, 9, 0))
+        );
+        when(meetingService.get(MEETING_ID)).thenThrow(new BusinessException(ErrorCode.MEETING_NOT_FOUND));
+
+        assertThatThrownBy(() -> participantFacade.createWithSchedule(MEETING_ID, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MEETING_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("일정 투표 기반 참여자 생성 시 localStorageKey 중복이면 예외를 던진다")
+    void createWithSchedule_duplicateLocalStorageKey() {
+        Meeting meeting = Meeting.of(10);
+        CreateParticipantWithScheduleRequest request = new CreateParticipantWithScheduleRequest(
+                "홍길동",
+                LOCAL_STORAGE_KEY,
+                List.of(LocalDateTime.of(2025, 2, 10, 9, 0))
+        );
+
+        when(meetingService.get(MEETING_ID)).thenReturn(meeting);
+        doThrow(new BusinessException(ErrorCode.DUPLICATE_LOCAL_STORAGE_KEY))
+                .when(participantService).validateLocalStorageKeyUnique(meeting, LOCAL_STORAGE_KEY);
+
+        assertThatThrownBy(() -> participantFacade.createWithSchedule(MEETING_ID, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DUPLICATE_LOCAL_STORAGE_KEY);
+    }
+
+    @Test
+    @DisplayName("일정 투표 기반 참여자 생성 시 일정 투표판이 없으면 예외를 던진다")
+    void createWithSchedule_schedulePollNotFound() {
+        Meeting meeting = Meeting.of(10);
+        Participant participant = Participant.of(meeting, LOCAL_STORAGE_KEY, "홍길동");
+        List<LocalDateTime> schedules = List.of(LocalDateTime.of(2025, 2, 10, 9, 0));
+        CreateParticipantWithScheduleRequest request = new CreateParticipantWithScheduleRequest(
+                "홍길동",
+                LOCAL_STORAGE_KEY,
+                schedules
+        );
+
+        when(meetingService.get(MEETING_ID)).thenReturn(meeting);
+        when(participantService.create(meeting, request.name(), request.localStorageKey())).thenReturn(participant);
+        when(scheduleVoteService.createVotes(meeting, participant, schedules))
+                .thenThrow(new BusinessException(ErrorCode.SCHEDULE_POLL_NOT_FOUND));
+
+        assertThatThrownBy(() -> participantFacade.createWithSchedule(MEETING_ID, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.SCHEDULE_POLL_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("위치 투표 기반 참여자 생성 성공 시 위치 투표 정보가 저장된다")
+    void createWithLocation_success() {
+        Meeting meeting = Meeting.of(10);
+        LocationPoll locationPoll = LocationPoll.defaultOf(meeting);
+        Participant participant = Participant.of(meeting, LOCAL_STORAGE_KEY, "이영희");
+        CreateParticipantWithLocationRequest request = new CreateParticipantWithLocationRequest(
+                "이영희",
+                LOCAL_STORAGE_KEY,
+                new CreateParticipantWithLocationRequest.LocationInput(
+                        new BigDecimal("37.5665"),
+                        new BigDecimal("126.9780"),
+                        "서울시 중구 명동"
+                )
+        );
+        LocationVote locationVote = LocationVote.of(
+                locationPoll,
+                participant,
+                request.location().address(),
+                request.location().latitude(),
+                request.location().longitude()
+        );
+
+        when(meetingService.get(MEETING_ID)).thenReturn(meeting);
+        when(participantService.create(meeting, request.name(), request.localStorageKey())).thenReturn(participant);
+        when(locationVoteService.createVote(
+                eq(meeting),
+                eq(participant),
+                eq(request.location().address()),
+                eq(request.location().latitude()),
+                eq(request.location().longitude())
+        )).thenReturn(locationVote);
+
+        CreateParticipantResponse response = participantFacade.createWithLocation(MEETING_ID, request);
+
+        assertThat(response.name()).isEqualTo(request.name());
+        assertThat(response.hasLocation()).isTrue();
+        assertThat(response.scheduleVoteCount()).isNull();
+
+        verify(participantService).validateLocalStorageKeyUnique(meeting, LOCAL_STORAGE_KEY);
+        verify(participantService).create(meeting, request.name(), request.localStorageKey());
+        verify(locationVoteService).createVote(
+                eq(meeting),
+                eq(participant),
+                eq(request.location().address()),
+                eq(request.location().latitude()),
+                eq(request.location().longitude())
+        );
+    }
+
+    @Test
+    @DisplayName("위치 투표 기반 참여자 생성 시 localStorageKey 중복이면 예외를 던진다")
+    void createWithLocation_duplicateLocalStorageKey() {
+        Meeting meeting = Meeting.of(10);
+        CreateParticipantWithLocationRequest request = new CreateParticipantWithLocationRequest(
+                "이영희",
+                LOCAL_STORAGE_KEY,
+                new CreateParticipantWithLocationRequest.LocationInput(
+                        new BigDecimal("37.5665"),
+                        new BigDecimal("126.9780"),
+                        "서울시 중구 명동"
+                )
+        );
+
+        when(meetingService.get(MEETING_ID)).thenReturn(meeting);
+        doThrow(new BusinessException(ErrorCode.DUPLICATE_LOCAL_STORAGE_KEY))
+                .when(participantService).validateLocalStorageKeyUnique(meeting, LOCAL_STORAGE_KEY);
+
+        assertThatThrownBy(() -> participantFacade.createWithLocation(MEETING_ID, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DUPLICATE_LOCAL_STORAGE_KEY);
+    }
+
+    @Test
+    @DisplayName("위치 투표 기반 참여자 생성 시 위치 투표판이 없으면 예외를 던진다")
+    void createWithLocation_locationPollNotFound() {
+        Meeting meeting = Meeting.of(10);
+        Participant participant = Participant.of(meeting, LOCAL_STORAGE_KEY, "이영희");
+        CreateParticipantWithLocationRequest request = new CreateParticipantWithLocationRequest(
+                "이영희",
+                LOCAL_STORAGE_KEY,
+                new CreateParticipantWithLocationRequest.LocationInput(
+                        new BigDecimal("37.5665"),
+                        new BigDecimal("126.9780"),
+                        "서울시 중구 명동"
+                )
+        );
+
+        when(meetingService.get(MEETING_ID)).thenReturn(meeting);
+        when(participantService.create(meeting, request.name(), request.localStorageKey())).thenReturn(participant);
+        when(locationVoteService.createVote(any(), any(), any(), any(), any()))
+                .thenThrow(new BusinessException(ErrorCode.LOCATION_POLL_NOT_FOUND));
+
+        assertThatThrownBy(() -> participantFacade.createWithLocation(MEETING_ID, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.LOCATION_POLL_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/dnd/moyeolak/domain/participant/service/ParticipantServiceImplTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/participant/service/ParticipantServiceImplTest.java
@@ -1,17 +1,9 @@
 package com.dnd.moyeolak.domain.participant.service;
 
-import com.dnd.moyeolak.domain.location.entity.LocationPoll;
 import com.dnd.moyeolak.domain.meeting.entity.Meeting;
-import com.dnd.moyeolak.domain.meeting.repository.MeetingRepository;
-import com.dnd.moyeolak.domain.participant.dto.CreateParticipantResponse;
-import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithLocationRequest;
-import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithScheduleRequest;
 import com.dnd.moyeolak.domain.participant.entity.Participant;
 import com.dnd.moyeolak.domain.participant.repository.ParticipantRepository;
 import com.dnd.moyeolak.domain.participant.service.impl.ParticipantServiceImpl;
-import com.dnd.moyeolak.domain.schedule.entity.SchedulePoll;
-import com.dnd.moyeolak.domain.schedule.repository.SchedulePollRepository;
-import com.dnd.moyeolak.domain.location.repository.LocationPollRepository;
 import com.dnd.moyeolak.global.exception.BusinessException;
 import com.dnd.moyeolak.global.response.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
@@ -22,203 +14,67 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ParticipantServiceImplTest {
 
-    private static final String MEETING_ID = "meeting-id";
     private static final String LOCAL_STORAGE_KEY = "local-storage-key";
 
     @Mock
-    private MeetingRepository meetingRepository;
-
-    @Mock
     private ParticipantRepository participantRepository;
-
-    @Mock
-    private SchedulePollRepository schedulePollRepository;
-
-    @Mock
-    private LocationPollRepository locationPollRepository;
 
     @InjectMocks
     private ParticipantServiceImpl participantService;
 
     @Test
-    @DisplayName("일정 투표 기반 참여자 생성 성공 시 투표 개수와 저장 여부를 반환한다")
-    void createWithSchedule_success() {
+    @DisplayName("참여자 생성 성공 시 저장된 참여자를 반환한다")
+    void create_success() {
         Meeting meeting = Meeting.of(10);
-        SchedulePoll schedulePoll = SchedulePoll.defaultOf(meeting);
-        CreateParticipantWithScheduleRequest request = new CreateParticipantWithScheduleRequest(
-                "홍길동",
-                LOCAL_STORAGE_KEY,
-                List.of(
-                        LocalDateTime.of(2025, 2, 10, 9, 0),
-                        LocalDateTime.of(2025, 2, 10, 10, 0)
-                )
-        );
+        String name = "홍길동";
 
-        when(meetingRepository.findById(MEETING_ID)).thenReturn(Optional.of(meeting));
-        when(participantRepository.existsByMeetingAndLocalStorageKey(meeting, LOCAL_STORAGE_KEY)).thenReturn(false);
-        when(schedulePollRepository.findByMeeting(meeting)).thenReturn(Optional.of(schedulePoll));
+        when(participantRepository.save(any(Participant.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
 
-        CreateParticipantResponse response = participantService.createWithSchedule(MEETING_ID, request);
+        Participant participant = participantService.create(meeting, name, LOCAL_STORAGE_KEY);
 
-        assertThat(response.name()).isEqualTo(request.name());
-        assertThat(response.scheduleVoteCount()).isEqualTo(request.availableSchedules().size());
-        assertThat(response.hasLocation()).isFalse();
+        assertThat(participant.getName()).isEqualTo(name);
+        assertThat(participant.getLocalStorageKey()).isEqualTo(LOCAL_STORAGE_KEY);
+        assertThat(participant.getMeeting()).isEqualTo(meeting);
 
         ArgumentCaptor<Participant> captor = ArgumentCaptor.forClass(Participant.class);
         verify(participantRepository).save(captor.capture());
-        Participant savedParticipant = captor.getValue();
-        assertThat(savedParticipant.getScheduleVotes()).hasSize(2);
-        assertThat(savedParticipant.getScheduleVotes().get(0).getSchedulePoll()).isEqualTo(schedulePoll);
-        assertThat(savedParticipant.getScheduleVotes().get(0).getParticipant()).isEqualTo(savedParticipant);
+        assertThat(captor.getValue().getName()).isEqualTo(name);
     }
 
     @Test
-    @DisplayName("일정 투표 기반 참여자 생성 시 모임을 찾지 못하면 예외를 던진다")
-    void createWithSchedule_meetingNotFound() {
-        CreateParticipantWithScheduleRequest request = new CreateParticipantWithScheduleRequest(
-                "홍길동",
-                LOCAL_STORAGE_KEY,
-                List.of(LocalDateTime.of(2025, 2, 10, 9, 0))
-        );
-        when(meetingRepository.findById(MEETING_ID)).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> participantService.createWithSchedule(MEETING_ID, request))
-                .isInstanceOf(BusinessException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.MEETING_NOT_FOUND);
-    }
-
-    @Test
-    @DisplayName("일정 투표 기반 참여자 생성 시 localStorageKey 중복이면 예외를 던진다")
-    void createWithSchedule_duplicateLocalStorageKey() {
+    @DisplayName("localStorageKey 중복 검증 시 중복이 없으면 예외를 던지지 않는다")
+    void validateLocalStorageKeyUnique_success() {
         Meeting meeting = Meeting.of(10);
-        CreateParticipantWithScheduleRequest request = new CreateParticipantWithScheduleRequest(
-                "홍길동",
-                LOCAL_STORAGE_KEY,
-                List.of(LocalDateTime.of(2025, 2, 10, 9, 0))
-        );
 
-        when(meetingRepository.findById(MEETING_ID)).thenReturn(Optional.of(meeting));
-        when(participantRepository.existsByMeetingAndLocalStorageKey(meeting, LOCAL_STORAGE_KEY)).thenReturn(true);
+        when(participantRepository.existsByMeetingAndLocalStorageKey(meeting, LOCAL_STORAGE_KEY))
+                .thenReturn(false);
 
-        assertThatThrownBy(() -> participantService.createWithSchedule(MEETING_ID, request))
+        participantService.validateLocalStorageKeyUnique(meeting, LOCAL_STORAGE_KEY);
+
+        verify(participantRepository).existsByMeetingAndLocalStorageKey(meeting, LOCAL_STORAGE_KEY);
+    }
+
+    @Test
+    @DisplayName("localStorageKey 중복 검증 시 중복이 있으면 예외를 던진다")
+    void validateLocalStorageKeyUnique_throwsExceptionWhenDuplicate() {
+        Meeting meeting = Meeting.of(10);
+
+        when(participantRepository.existsByMeetingAndLocalStorageKey(meeting, LOCAL_STORAGE_KEY))
+                .thenReturn(true);
+
+        assertThatThrownBy(() -> participantService.validateLocalStorageKeyUnique(meeting, LOCAL_STORAGE_KEY))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.DUPLICATE_LOCAL_STORAGE_KEY);
-    }
-
-    @Test
-    @DisplayName("일정 투표 기반 참여자 생성 시 일정 투표판이 없으면 예외를 던진다")
-    void createWithSchedule_schedulePollNotFound() {
-        Meeting meeting = Meeting.of(10);
-        CreateParticipantWithScheduleRequest request = new CreateParticipantWithScheduleRequest(
-                "홍길동",
-                LOCAL_STORAGE_KEY,
-                List.of(LocalDateTime.of(2025, 2, 10, 9, 0))
-        );
-
-        when(meetingRepository.findById(MEETING_ID)).thenReturn(Optional.of(meeting));
-        when(participantRepository.existsByMeetingAndLocalStorageKey(meeting, LOCAL_STORAGE_KEY)).thenReturn(false);
-        when(schedulePollRepository.findByMeeting(meeting)).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> participantService.createWithSchedule(MEETING_ID, request))
-                .isInstanceOf(BusinessException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.SCHEDULE_POLL_NOT_FOUND);
-    }
-
-    @Test
-    @DisplayName("위치 투표 기반 참여자 생성 성공 시 위치 투표 정보가 저장된다")
-    void createWithLocation_success() {
-        Meeting meeting = Meeting.of(10);
-        LocationPoll locationPoll = LocationPoll.defaultOf(meeting);
-        CreateParticipantWithLocationRequest request = new CreateParticipantWithLocationRequest(
-                "이영희",
-                LOCAL_STORAGE_KEY,
-                new CreateParticipantWithLocationRequest.LocationInput(
-                        new BigDecimal("37.5665"),
-                        new BigDecimal("126.9780"),
-                        "서울시 중구 명동"
-                )
-        );
-
-        when(meetingRepository.findById(MEETING_ID)).thenReturn(Optional.of(meeting));
-        when(participantRepository.existsByMeetingAndLocalStorageKey(meeting, LOCAL_STORAGE_KEY)).thenReturn(false);
-        when(locationPollRepository.findByMeeting(meeting)).thenReturn(Optional.of(locationPoll));
-
-        CreateParticipantResponse response = participantService.createWithLocation(MEETING_ID, request);
-
-        assertThat(response.name()).isEqualTo(request.name());
-        assertThat(response.hasLocation()).isTrue();
-        assertThat(response.scheduleVoteCount()).isNull();
-
-        ArgumentCaptor<Participant> captor = ArgumentCaptor.forClass(Participant.class);
-        verify(participantRepository).save(captor.capture());
-        Participant savedParticipant = captor.getValue();
-        assertThat(savedParticipant.getLocationVotes()).hasSize(1);
-        assertThat(savedParticipant.getLocationVotes().get(0).getLocationPoll()).isEqualTo(locationPoll);
-        assertThat(savedParticipant.getLocationVotes().get(0).getDepartureLat()).isEqualTo(request.location().latitude());
-        assertThat(savedParticipant.getLocationVotes().get(0).getDepartureLng()).isEqualTo(request.location().longitude());
-        assertThat(savedParticipant.getLocationVotes().get(0).getDepartureLocation()).isEqualTo(request.location().address());
-    }
-
-    @Test
-    @DisplayName("위치 투표 기반 참여자 생성 시 localStorageKey 중복이면 예외를 던진다")
-    void createWithLocation_duplicateLocalStorageKey() {
-        Meeting meeting = Meeting.of(10);
-        CreateParticipantWithLocationRequest request = new CreateParticipantWithLocationRequest(
-                "이영희",
-                LOCAL_STORAGE_KEY,
-                new CreateParticipantWithLocationRequest.LocationInput(
-                        new BigDecimal("37.5665"),
-                        new BigDecimal("126.9780"),
-                        "서울시 중구 명동"
-                )
-        );
-
-        when(meetingRepository.findById(MEETING_ID)).thenReturn(Optional.of(meeting));
-        when(participantRepository.existsByMeetingAndLocalStorageKey(meeting, LOCAL_STORAGE_KEY)).thenReturn(true);
-
-        assertThatThrownBy(() -> participantService.createWithLocation(MEETING_ID, request))
-                .isInstanceOf(BusinessException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.DUPLICATE_LOCAL_STORAGE_KEY);
-    }
-
-    @Test
-    @DisplayName("위치 투표 기반 참여자 생성 시 위치 투표판이 없으면 예외를 던진다")
-    void createWithLocation_locationPollNotFound() {
-        Meeting meeting = Meeting.of(10);
-        CreateParticipantWithLocationRequest request = new CreateParticipantWithLocationRequest(
-                "이영희",
-                LOCAL_STORAGE_KEY,
-                new CreateParticipantWithLocationRequest.LocationInput(
-                        new BigDecimal("37.5665"),
-                        new BigDecimal("126.9780"),
-                        "서울시 중구 명동"
-                )
-        );
-
-        when(meetingRepository.findById(MEETING_ID)).thenReturn(Optional.of(meeting));
-        when(participantRepository.existsByMeetingAndLocalStorageKey(meeting, LOCAL_STORAGE_KEY)).thenReturn(false);
-        when(locationPollRepository.findByMeeting(meeting)).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> participantService.createWithLocation(MEETING_ID, request))
-                .isInstanceOf(BusinessException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.LOCATION_POLL_NOT_FOUND);
     }
 }

--- a/src/test/java/com/dnd/moyeolak/domain/schedule/service/ScheduleVoteServiceImplTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/schedule/service/ScheduleVoteServiceImplTest.java
@@ -1,0 +1,69 @@
+package com.dnd.moyeolak.domain.schedule.service;
+
+import com.dnd.moyeolak.domain.meeting.entity.Meeting;
+import com.dnd.moyeolak.domain.participant.entity.Participant;
+import com.dnd.moyeolak.domain.schedule.entity.SchedulePoll;
+import com.dnd.moyeolak.domain.schedule.entity.ScheduleVote;
+import com.dnd.moyeolak.domain.schedule.repository.SchedulePollRepository;
+import com.dnd.moyeolak.domain.schedule.service.impl.ScheduleVoteServiceImpl;
+import com.dnd.moyeolak.global.exception.BusinessException;
+import com.dnd.moyeolak.global.response.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ScheduleVoteServiceImplTest {
+
+    @Mock
+    private SchedulePollRepository schedulePollRepository;
+
+    @InjectMocks
+    private ScheduleVoteServiceImpl scheduleVoteService;
+
+    @Test
+    @DisplayName("일정 투표 생성 성공 시 투표 목록을 반환한다")
+    void createVotes_success() {
+        Meeting meeting = Meeting.of(10);
+        SchedulePoll schedulePoll = SchedulePoll.defaultOf(meeting);
+        Participant participant = Participant.of(meeting, "local-key", "홍길동");
+        List<LocalDateTime> schedules = List.of(
+                LocalDateTime.of(2025, 2, 10, 9, 0),
+                LocalDateTime.of(2025, 2, 10, 10, 0)
+        );
+
+        when(schedulePollRepository.findByMeeting(meeting)).thenReturn(Optional.of(schedulePoll));
+
+        List<ScheduleVote> result = scheduleVoteService.createVotes(meeting, participant, schedules);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getParticipant()).isEqualTo(participant);
+        assertThat(result.get(0).getSchedulePoll()).isEqualTo(schedulePoll);
+    }
+
+    @Test
+    @DisplayName("일정 투표판이 없으면 예외를 던진다")
+    void createVotes_throwsExceptionWhenSchedulePollNotFound() {
+        Meeting meeting = Meeting.of(10);
+        Participant participant = Participant.of(meeting, "local-key", "홍길동");
+        List<LocalDateTime> schedules = List.of(LocalDateTime.of(2025, 2, 10, 9, 0));
+
+        when(schedulePollRepository.findByMeeting(meeting)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> scheduleVoteService.createVotes(meeting, participant, schedules))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.SCHEDULE_POLL_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## Summary

- ParticipantController 엔드포인트를 `/api/meetings/{meetingId}/participants`에서 `/api/participants`로 변경
- ParticipantFacade 도입으로 유스케이스 조율 계층 분리
- ScheduleVoteService, LocationVoteService를 각 도메인에 맞게 분리

## 변경 이유

### 기존 문제점: 도메인 경계 침범

기존 `ParticipantService`가 4개의 Repository에 의존하고 있었습니다:

```java
// Before: ParticipantServiceImpl
private final MeetingRepository meetingRepository;      // meeting 도메인
private final ParticipantRepository participantRepository;
private final SchedulePollRepository schedulePollRepository;  // schedule 도메인
private final LocationPollRepository locationPollRepository;  // location 도메인
```

이는 **DDD의 Bounded Context 원칙**을 위반합니다:
- 도메인 간 결합도가 높아져 변경에 취약
- 단일 책임 원칙(SRP) 위반 - 변경 이유가 3개 (참여자/일정투표/위치투표)
- 테스트 시 불필요한 의존성 모킹 필요

### 왜 Facade 패턴인가?

#### 고려했던 대안: API 분리

```
# 참여자 생성
POST /api/participants

# 일정 투표 생성 (별도 호출)
POST /api/schedule-votes
```

**문제점** (프론트엔드 팀 피드백):
- 하나의 유스케이스인데 API가 분리되면 **책임/역할이 분산**됨
- 에러 발생 시 **어느 API에서 실패했는지 추적이 번거로움**
- 참여자는 생성됐는데 투표는 실패하면? → **데이터 정합성 관리 복잡**

#### 선택한 방법: Facade 패턴

**단일 API로 유지**하면서 **백엔드 내부만 책임 분리**

```
┌─────────────────────────────────────────────────────┐
│              ParticipantController                  │
└─────────────────────┬───────────────────────────────┘
                      │ 단일 API (에러도 한 곳에서 처리)
┌─────────────────────▼───────────────────────────────┐
│              ParticipantFacade                      │  ← 트랜잭션 + 에러 관리
└───┬─────────────┬─────────────┬─────────────────────┘
    │             │             │
    ▼             ▼             ▼
┌────────┐  ┌──────────┐  ┌────────────┐
│Meeting │  │Participant│  │ScheduleVote│  ...
│Service │  │ Service   │  │  Service   │
└────────┘  └──────────┘  └────────────┘
```

| 구분 | API 분리 | Facade 패턴 (채택) |
|------|----------|-------------------|
| 프론트 책임 | 여러 API 조합 필요 | **단일 API 호출** |
| 에러 추적 | 어느 API 실패인지 확인 필요 | **한 곳에서 명확한 에러 응답** |
| 데이터 정합성 | 부분 실패 시 롤백 처리 복잡 | **단일 트랜잭션으로 보장** |
| 백엔드 구조 | 도메인 분리 | **도메인 분리** |

**결론**: 프론트엔드에는 단순한 단일 API, 백엔드 내부는 책임 분리 → **양쪽 모두 만족**

### API 엔드포인트 변경 이유

| Before | After |
|--------|-------|
| `POST /api/meetings/{meetingId}/participants/schedule` | `POST /api/participants/join-with-schedule?meetingId=xxx` |

Participant는 자체 ID, 투표, 일정 등 **독립적인 행위**를 가지므로 Nested Resource가 아닌 **Independent Resource**로 설계하는 것이 RESTful 원칙에 부합합니다.

## Test plan

- [x] ParticipantFacadeTest - Facade 레이어 단위 테스트
- [x] ParticipantServiceImplTest - 서비스 레이어 단위 테스트
- [x] ParticipantControllerTest - 컨트롤러 레이어 단위 테스트
- [x] 전체 빌드 성공 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)