### PR TITLE
feat: enforce participant localStorageKey uniqueness

### DIFF
--- a/src/main/java/com/dnd/moyeolak/domain/participant/entity/Participant.java
+++ b/src/main/java/com/dnd/moyeolak/domain/participant/entity/Participant.java
@@ -13,6 +13,13 @@ import java.util.List;
 
 @Getter
 @Entity
+@Table(
+        name = "participant",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_participant_meeting_local_storage_key",
+                columnNames = {"meeting_id", "local_storage_key"}
+        )
+)
 @Builder(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,7 +33,7 @@ public class Participant extends BaseEntity {
     @JoinColumn(name = "meeting_id", nullable = false)
     private Meeting meeting;
 
-    @Column(comment = "고유키")
+    @Column(name = "local_storage_key", comment = "고유키")
     private String localStorageKey;
 
     @Column(comment = "이름", nullable = false)


### PR DESCRIPTION
## Issue Number
closed #0

## As-Is
- DB 레벨에서 meeting+localStorageKey 중복 방지 장치가 없어 동시성 상황에서 중복 참여자가 저장될 수 있었음.
- 관련 정책 문서도 없어 컨텍스트 공유가 어려웠음.

## To-Be
- Participant 엔티티에 `meeting_id + local_storage_key` 유니크 제약을 추가해 중복 삽입 차단.
- 변경 배경과 기대 효과를 `.claude/Api/participant-localstoragekey-unique.md`에 문서화.

## Review Request (중요)
- 코드 리뷰는 **한국어로 작성**해주세요.
- 구현 의도, 리스크, 개선 포인트 중심으로 리뷰 부탁드립니다.

## Check List
- [ ] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [ ] Assignee를 지정했나요?
- [ ] Label을 지정했나요?
- [ ] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
- 테스트 미실행 (`./gradlew test`)
