### PR TITLE
feat(participant): 모임별 참여자 전체 조회 API 추가

### DIFF
--- a/src/main/java/com/dnd/moyeolak/domain/participant/controller/ParticipantController.java
+++ b/src/main/java/com/dnd/moyeolak/domain/participant/controller/ParticipantController.java
@@ -4,6 +4,7 @@ import com.dnd.moyeolak.domain.participant.dto.CreateParticipantResponse;
 import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithLocationRequest;
 import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithScheduleRequest;
 import com.dnd.moyeolak.domain.participant.dto.GetParticipantResponse;
+import com.dnd.moyeolak.domain.participant.dto.ListParticipantResponse;
 import com.dnd.moyeolak.domain.participant.service.ParticipantService;
 import com.dnd.moyeolak.global.response.ApiResponse;
 import com.dnd.moyeolak.global.response.SuccessCode;
@@ -251,6 +252,70 @@ public class ParticipantController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.success(SuccessCode.RESOURCE_CREATED, response));
+    }
+
+    @GetMapping
+    @Operation(summary = "참여자 전체 조회", description = """
+            모임에 참여한 모든 참여자 목록을 조회합니다.
+
+            ### 사용 시점
+            - 모임 상세 페이지에서 참여자 목록을 표시할 때
+            """)
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "참여자 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ListParticipantResponse.class),
+                            examples = @ExampleObject(
+                                    name = "성공 응답",
+                                    value = """
+                                            {
+                                              "code": "S100",
+                                              "message": "요청이 성공적으로 처리되었습니다.",
+                                              "data": {
+                                                "participants": [
+                                                  {
+                                                    "participantId": 1,
+                                                    "name": "김철수",
+                                                    "isHost": true
+                                                  },
+                                                  {
+                                                    "participantId": 2,
+                                                    "name": "이영희",
+                                                    "isHost": false
+                                                  }
+                                                ],
+                                                "totalCount": 2
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "모임을 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "모임 없음",
+                                    value = """
+                                            {
+                                              "code": "E410",
+                                              "message": "모임이 존재하지 않습니다."
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    public ResponseEntity<ApiResponse<ListParticipantResponse>> listParticipants(
+            @Parameter(description = "조회할 모임 ID", example = "abc123", required = true)
+            @RequestParam String meetingId) {
+        ListParticipantResponse response = participantService.listParticipants(meetingId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @GetMapping("/{participantId}")

--- a/src/main/java/com/dnd/moyeolak/domain/participant/dto/ListParticipantResponse.java
+++ b/src/main/java/com/dnd/moyeolak/domain/participant/dto/ListParticipantResponse.java
@@ -1,0 +1,42 @@
+package com.dnd.moyeolak.domain.participant.dto;
+
+import com.dnd.moyeolak.domain.participant.entity.Participant;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "참여자 전체 조회 응답")
+public record ListParticipantResponse(
+        @Schema(description = "참여자 목록")
+        List<ParticipantInfo> participants,
+
+        @Schema(description = "총 참여자 수", example = "3")
+        int totalCount
+) {
+    @Schema(description = "참여자 정보")
+    public record ParticipantInfo(
+            @Schema(description = "참여자 ID", example = "1")
+            Long participantId,
+
+            @Schema(description = "참여자 이름", example = "김철수")
+            String name,
+
+            @Schema(description = "방장 여부", example = "false")
+            boolean isHost
+    ) {
+        public static ParticipantInfo from(Participant participant) {
+            return new ParticipantInfo(
+                    participant.getParticipantId(),
+                    participant.getName(),
+                    participant.isHost()
+            );
+        }
+    }
+
+    public static ListParticipantResponse from(List<Participant> participants) {
+        List<ParticipantInfo> infos = participants.stream()
+                .map(ParticipantInfo::from)
+                .toList();
+        return new ListParticipantResponse(infos, infos.size());
+    }
+}

--- a/src/main/java/com/dnd/moyeolak/domain/participant/service/ParticipantService.java
+++ b/src/main/java/com/dnd/moyeolak/domain/participant/service/ParticipantService.java
@@ -4,6 +4,7 @@ import com.dnd.moyeolak.domain.participant.dto.CreateParticipantResponse;
 import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithLocationRequest;
 import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithScheduleRequest;
 import com.dnd.moyeolak.domain.participant.dto.GetParticipantResponse;
+import com.dnd.moyeolak.domain.participant.dto.ListParticipantResponse;
 import com.dnd.moyeolak.domain.participant.entity.Participant;
 
 public interface ParticipantService {
@@ -13,6 +14,8 @@ public interface ParticipantService {
     CreateParticipantResponse createWithLocation(String meetingId, CreateParticipantWithLocationRequest request);
 
     GetParticipantResponse getParticipant(Long participantId);
+
+    ListParticipantResponse listParticipants(String meetingId);
 
     void save(Participant participant);
 }

--- a/src/main/java/com/dnd/moyeolak/domain/participant/service/impl/ParticipantServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/participant/service/impl/ParticipantServiceImpl.java
@@ -8,6 +8,7 @@ import com.dnd.moyeolak.domain.participant.dto.CreateParticipantResponse;
 import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithLocationRequest;
 import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithScheduleRequest;
 import com.dnd.moyeolak.domain.participant.dto.GetParticipantResponse;
+import com.dnd.moyeolak.domain.participant.dto.ListParticipantResponse;
 import com.dnd.moyeolak.domain.participant.entity.Participant;
 import com.dnd.moyeolak.domain.participant.repository.ParticipantRepository;
 import com.dnd.moyeolak.domain.participant.service.ParticipantService;
@@ -83,6 +84,12 @@ public class ParticipantServiceImpl implements ParticipantService {
         Participant participant = participantRepository.findById(participantId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PARTICIPANT_NOT_FOUND));
         return GetParticipantResponse.from(participant);
+    }
+
+    @Override
+    public ListParticipantResponse listParticipants(String meetingId) {
+        Meeting meeting = meetingService.get(meetingId);
+        return ListParticipantResponse.from(meeting.getParticipants());
     }
 
     @Override

--- a/src/test/java/com/dnd/moyeolak/domain/participant/service/ParticipantServiceImplTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/participant/service/ParticipantServiceImplTest.java
@@ -7,6 +7,7 @@ import com.dnd.moyeolak.domain.participant.dto.CreateParticipantResponse;
 import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithLocationRequest;
 import com.dnd.moyeolak.domain.participant.dto.CreateParticipantWithScheduleRequest;
 import com.dnd.moyeolak.domain.participant.dto.GetParticipantResponse;
+import com.dnd.moyeolak.domain.participant.dto.ListParticipantResponse;
 import com.dnd.moyeolak.domain.participant.entity.Participant;
 import com.dnd.moyeolak.domain.participant.repository.ParticipantRepository;
 import com.dnd.moyeolak.domain.participant.service.impl.ParticipantServiceImpl;
@@ -216,6 +217,58 @@ class ParticipantServiceImplTest {
         assertThat(response.participantId()).isEqualTo(hostParticipant.getParticipantId());
         assertThat(response.name()).isEqualTo("이방장");
         assertThat(response.isHost()).isTrue();
+    }
+
+    @Test
+    @DisplayName("참여자 전체 조회 성공 시 참여자 목록을 반환한다")
+    void listParticipants_success() {
+        // Given
+        Meeting meeting = Meeting.of(10);
+        Participant host = Participant.hostOf(meeting, "host-key", "김방장");
+        Participant member = Participant.of(meeting, "member-key", "이참여");
+        meeting.addParticipant(host);
+        meeting.addParticipant(member);
+
+        when(meetingService.get(MEETING_ID)).thenReturn(meeting);
+
+        // When
+        ListParticipantResponse response = participantService.listParticipants(MEETING_ID);
+
+        // Then
+        assertThat(response.totalCount()).isEqualTo(2);
+        assertThat(response.participants()).hasSize(2);
+        assertThat(response.participants().get(0).name()).isEqualTo("김방장");
+        assertThat(response.participants().get(0).isHost()).isTrue();
+        assertThat(response.participants().get(1).name()).isEqualTo("이참여");
+        assertThat(response.participants().get(1).isHost()).isFalse();
+    }
+
+    @Test
+    @DisplayName("참여자가 없는 모임 전체 조회 시 빈 목록을 반환한다")
+    void listParticipants_emptyList() {
+        // Given
+        Meeting meeting = Meeting.of(10);
+        when(meetingService.get(MEETING_ID)).thenReturn(meeting);
+
+        // When
+        ListParticipantResponse response = participantService.listParticipants(MEETING_ID);
+
+        // Then
+        assertThat(response.totalCount()).isZero();
+        assertThat(response.participants()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("참여자 전체 조회 시 모임을 찾지 못하면 예외를 던진다")
+    void listParticipants_meetingNotFound() {
+        // Given
+        when(meetingService.get(MEETING_ID)).thenThrow(new BusinessException(ErrorCode.MEETING_NOT_FOUND));
+
+        // When & Then
+        assertThatThrownBy(() -> participantService.listParticipants(MEETING_ID))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MEETING_NOT_FOUND);
     }
 
     @Test


### PR DESCRIPTION
## Issue Number
closed #8

## As-Is
모임에 참여한 참여자를 개별 조회(`GET /api/participants/{participantId}`)만 가능하고, 모임 단위로 전체 참여자 목록을 조회하는 API가 없음

## To-Be
- `GET /api/participants?meetingId={meetingId}` 엔드포인트 추가
- 모임 ID로 해당 모임의 전체 참여자 목록(participantId, name, isHost)과 총 인원수(totalCount) 반환
- Aggregate Root(Meeting)를 통해 참여자 접근 (Cascade 패턴 준수)
- Controller/Service 테스트 코드 포함 (총 5건)

## Review Request (중요)
- 코드 리뷰는 **한국어로 작성**해주세요.
- 구현 의도, 리스크, 개선 포인트 중심으로 리뷰 부탁드립니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?