### PR TITLE
refactor (config) : Swagger 서버 URL 자동 선택으로 변경

### DIFF
--- a/src/main/java/com/dnd/moyeolak/global/config/SwaggerConfig.java
+++ b/src/main/java/com/dnd/moyeolak/global/config/SwaggerConfig.java
@@ -2,29 +2,15 @@ package com.dnd.moyeolak.global.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.util.List;
 
 @Configuration
 public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
-        Server localServer = new Server()
-                .url("http://localhost:8080")
-                .description("Local 환경");
-        Server devServer = new Server()
-                .url("http://prod-moyeorak-alb-127485029-3acfa245edb4.kr.lb.naverncp.com")
-                .description("Dev 환경");
-        Server prodServer = new Server()
-                .url("http://prod-moyeorak-alb-127485029-3acfa245edb4.kr.lb.naverncp.com")
-                .description("Production 환경");
-
         return new OpenAPI()
-                .servers(List.of(localServer, devServer, prodServer))
                 .info(new Info()
                         .title("모여락 API")
                         .description("모여락 서비스 API 문서")


### PR DESCRIPTION
## Issue Number
closed #49

## As-Is
SwaggerConfig에 서버 URL이 하드코딩되어 있어, 환경이 변경될 때마다 코드를 수정해야 했음

## To-Be
서버 목록을 제거하여 Swagger UI가 현재 접속한 URL을 기준으로 API 요청을 자동 전송하도록 변경

## Review Request (중요)
- 코드 리뷰는 **한국어로 작성**해주세요.
- 구현 의도, 리스크, 개선 포인트 중심으로 리뷰 부탁드립니다.

## Check List
- [ ] 테스트가 전부 통과되었나요?
- [ ] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [ ] Assignee를 지정했나요?
- [ ] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
- OpenAPI spec에서 `servers` 배열을 생략하면, Swagger UI가 현재 브라우저 origin 기준으로 요청을 보냄
- 불필요한 `Server`, `List` import 제거