### PR TITLE
fix(schedule): 시간 투표 생성 시 transient Meeting 참조로 인한 E409 오류 수정

### DIFF
--- a/src/main/java/com/dnd/moyeolak/domain/schedule/service/impl/ScheduleVoteServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/schedule/service/impl/ScheduleVoteServiceImpl.java
@@ -46,7 +46,7 @@ public class ScheduleVoteServiceImpl implements ScheduleVoteService {
 
         ScheduleVote scheduleVote = ScheduleVote.of(schedulePoll, request.votedDates());
         Participant participant = Participant.of(
-                Meeting.ofId(meetingId), request.localStorageKey(), request.participantName(), scheduleVote
+                meeting, request.localStorageKey(), request.participantName(), scheduleVote
         );
         participantService.save(participant);
 


### PR DESCRIPTION
## Summary

- `ScheduleVoteServiceImpl.createParticipantVote()`에서 `Participant.of()` 호출 시 `Meeting.ofId(meetingId)`로 생성한 transient 엔티티를 전달하던 버그 수정
- 이미 `findByIdWithAllAssociations()`로 로드한 managed 엔티티 `meeting` 변수를 재사용하도록 변경
- transient 엔티티 참조로 인해 Hibernate가 `PropertyValueException`을 던지고, Spring이 이를 `DataIntegrityViolationException`으로 변환하여 E409 응답이 발생하는 문제 해결

## Problem

신규 참여자가 `POST /api/schedules/vote`를 호출했을 때 `{"code":"E409","message":"이미 존재하는 리소스입니다."}` 오류가 반환됨

**원인**
```java
// Before (버그)
Participant participant = Participant.of(
    Meeting.ofId(meetingId),  // transient 엔티티 → PropertyValueException → E409
    ...
);

// After (수정)
Participant participant = Participant.of(
    meeting,  // findByIdWithAllAssociations로 로드한 managed 엔티티
    ...
);
```

## Test plan

- [ ] 신규 참여자가 `POST /api/schedules/vote` 호출 시 정상적으로 201 응답 반환되는지 확인
- [ ] 중복 `localStorageKey`로 재요청 시 E413 응답 반환되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)