### PR TITLE
feat(location): 모임장 출발지 추가 가능하도록 수정

### DIFF
--- a/src/main/java/com/dnd/moyeolak/domain/participant/entity/Participant.java
+++ b/src/main/java/com/dnd/moyeolak/domain/participant/entity/Participant.java
@@ -91,7 +91,7 @@ public class Participant extends BaseEntity {
         scheduleVote.assignParticipant(this);
     }
 
-    private void addLocationVote(LocationVote locationVote) {
+    public void addLocationVote(LocationVote locationVote) {
         this.locationVotes.add(locationVote);
         locationVote.assignParticipant(this);
     }

--- a/src/test/java/com/dnd/moyeolak/domain/location/service/LocationVoteUnitTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/location/service/LocationVoteUnitTest.java
@@ -2,12 +2,16 @@ package com.dnd.moyeolak.domain.location.service;
 
 import com.dnd.moyeolak.domain.location.dto.CreateLocationVoteRequest;
 import com.dnd.moyeolak.domain.location.entity.LocationVote;
-import com.dnd.moyeolak.domain.location.repository.LocationPollRepository;
 import com.dnd.moyeolak.domain.location.repository.LocationVoteRepository;
 import com.dnd.moyeolak.domain.location.service.impl.LocationVoteServiceImpl;
+import com.dnd.moyeolak.domain.meeting.entity.Meeting;
+import com.dnd.moyeolak.domain.meeting.service.MeetingService;
 import com.dnd.moyeolak.domain.participant.entity.Participant;
 import com.dnd.moyeolak.domain.participant.service.ParticipantService;
+import com.dnd.moyeolak.global.exception.BusinessException;
+import com.dnd.moyeolak.global.response.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -18,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.math.BigDecimal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -25,10 +30,10 @@ import static org.mockito.Mockito.*;
 class LocationVoteUnitTest {
 
     @Mock
-    private ParticipantService participantService;
+    private MeetingService meetingService;
 
     @Mock
-    private LocationPollRepository locationPollRepository;
+    private ParticipantService participantService;
 
     @Mock
     private LocationVoteRepository locationVoteRepository;
@@ -36,114 +41,240 @@ class LocationVoteUnitTest {
     @InjectMocks
     private LocationVoteServiceImpl locationService;
 
-    @Test
-    @DisplayName("수동 추가 시 LocationVote만 저장된다")
-    void createLocationVote_manualAdd_savesLocationVoteOnly() {
-        // given
-        CreateLocationVoteRequest request = new CreateLocationVoteRequest(
-                "meeting-id-123",
-                "1",
-                null,  // localStorageKey가 null → 수동 추가
-                "홍길동",
-                "서울시 강남구",
-                "37.4979502",
-                "127.0276368"
-        );
+    @Nested
+    @DisplayName("수동 추가 (localStorageKey 없음)")
+    class ManualAdd {
 
-        // when
-        locationService.createLocationVote(request);
+        @Test
+        @DisplayName("수동 추가 시 LocationVote만 저장된다")
+        void createLocationVote_manualAdd_savesLocationVoteOnly() {
+            // given
+            CreateLocationVoteRequest request = new CreateLocationVoteRequest(
+                    "meeting-id-123",
+                    "1",
+                    null,  // localStorageKey가 null → 수동 추가
+                    "홍길동",
+                    "서울시 강남구",
+                    "37.4979502",
+                    "127.0276368"
+            );
 
-        // then
-        ArgumentCaptor<LocationVote> captor = ArgumentCaptor.forClass(LocationVote.class);
-        verify(locationVoteRepository).save(captor.capture());
+            // when
+            locationService.createLocationVote(request);
 
-        LocationVote savedVote = captor.getValue();
-        assertThat(savedVote.getDepartureName()).isEqualTo("홍길동");
-        assertThat(savedVote.getDepartureLocation()).isEqualTo("서울시 강남구");
-        assertThat(savedVote.getDepartureLat()).isEqualByComparingTo(new BigDecimal("37.4979502"));
-        assertThat(savedVote.getDepartureLng()).isEqualByComparingTo(new BigDecimal("127.0276368"));
+            // then
+            ArgumentCaptor<LocationVote> captor = ArgumentCaptor.forClass(LocationVote.class);
+            verify(locationVoteRepository).save(captor.capture());
 
-        verify(participantService, never()).save(any());
+            LocationVote savedVote = captor.getValue();
+            assertThat(savedVote.getDepartureName()).isEqualTo("홍길동");
+            assertThat(savedVote.getDepartureLocation()).isEqualTo("서울시 강남구");
+            assertThat(savedVote.getDepartureLat()).isEqualByComparingTo(new BigDecimal("37.4979502"));
+            assertThat(savedVote.getDepartureLng()).isEqualByComparingTo(new BigDecimal("127.0276368"));
+
+            verify(participantService, never()).save(any());
+            verify(meetingService, never()).get(any());
+        }
+
+        @Test
+        @DisplayName("수동 추가 시 빈 문자열 localStorageKey도 수동 추가로 처리된다")
+        void createLocationVote_emptyLocalStorageKey_savesLocationVoteOnly() {
+            // given
+            CreateLocationVoteRequest request = new CreateLocationVoteRequest(
+                    "meeting-id-123",
+                    "1",
+                    "",  // 빈 문자열 → 수동 추가
+                    "김철수",
+                    "서울시 홍대입구",
+                    "37.5571010",
+                    "126.9236450"
+            );
+
+            // when
+            locationService.createLocationVote(request);
+
+            // then
+            verify(locationVoteRepository).save(any(LocationVote.class));
+            verify(participantService, never()).save(any());
+            verify(meetingService, never()).get(any());
+        }
     }
 
-    @Test
-    @DisplayName("수동 추가 시 빈 문자열 localStorageKey도 수동 추가로 처리된다")
-    void createLocationVote_emptyLocalStorageKey_savesLocationVoteOnly() {
-        // given
-        CreateLocationVoteRequest request = new CreateLocationVoteRequest(
-                "meeting-id-123",
-                "1",
-                "",  // 빈 문자열 → 수동 추가
-                "김철수",
-                "서울시 홍대입구",
-                "37.5571010",
-                "126.9236450"
-        );
+    @Nested
+    @DisplayName("실 참여자 추가 (localStorageKey 있음, 신규 참여자)")
+    class NewParticipantAdd {
 
-        // when
-        locationService.createLocationVote(request);
+        @Test
+        @DisplayName("신규 참여자 추가 시 Participant와 LocationVote가 함께 저장된다")
+        void createLocationVote_participantAdd_savesParticipantWithLocationVote() {
+            // given
+            String meetingId = "meeting-id-123";
+            Meeting meeting = Meeting.ofId(meetingId);
+            // 기존 참여자 없음 → meeting.getParticipants()는 비어있음
 
-        // then
-        verify(locationVoteRepository).save(any(LocationVote.class));
-        verify(participantService, never()).save(any());
+            CreateLocationVoteRequest request = new CreateLocationVoteRequest(
+                    meetingId,
+                    "1",
+                    "local-storage-key-abc",  // localStorageKey 존재, 신규 참여자
+                    "이영희",
+                    "서울시 왕십리",
+                    "37.5614080",
+                    "127.0379670"
+            );
+
+            when(meetingService.get(meetingId)).thenReturn(meeting);
+
+            // when
+            locationService.createLocationVote(request);
+
+            // then
+            ArgumentCaptor<Participant> captor = ArgumentCaptor.forClass(Participant.class);
+            verify(participantService).save(captor.capture());
+
+            Participant savedParticipant = captor.getValue();
+            assertThat(savedParticipant.getName()).isEqualTo("이영희");
+            assertThat(savedParticipant.getLocalStorageKey()).isEqualTo("local-storage-key-abc");
+            assertThat(savedParticipant.getLocationVotes()).hasSize(1);
+
+            LocationVote locationVote = savedParticipant.getLocationVotes().get(0);
+            assertThat(locationVote.getDepartureLocation()).isEqualTo("서울시 왕십리");
+            assertThat(locationVote.getDepartureLat()).isEqualByComparingTo(new BigDecimal("37.5614080"));
+            assertThat(locationVote.getDepartureLng()).isEqualByComparingTo(new BigDecimal("127.0379670"));
+
+            verify(locationVoteRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("신규 참여자 추가 시 Meeting ID가 올바르게 세팅된다")
+        void createLocationVote_participantAdd_setsMeetingId() {
+            // given
+            String meetingId = "meeting-id-456";
+            Meeting meeting = Meeting.ofId(meetingId);
+
+            CreateLocationVoteRequest request = new CreateLocationVoteRequest(
+                    meetingId,
+                    "1",
+                    "local-storage-key-xyz",
+                    "박민수",
+                    "서울시 서초구",
+                    "37.4837121",
+                    "127.0324112"
+            );
+
+            when(meetingService.get(meetingId)).thenReturn(meeting);
+
+            // when
+            locationService.createLocationVote(request);
+
+            // then
+            ArgumentCaptor<Participant> captor = ArgumentCaptor.forClass(Participant.class);
+            verify(participantService).save(captor.capture());
+
+            Participant savedParticipant = captor.getValue();
+            assertThat(savedParticipant.getMeeting().getId()).isEqualTo(meetingId);
+        }
     }
 
-    @Test
-    @DisplayName("실 참여자 추가 시 Participant와 LocationVote가 함께 저장된다")
-    void createLocationVote_participantAdd_savesParticipantWithLocationVote() {
-        // given
-        CreateLocationVoteRequest request = new CreateLocationVoteRequest(
-                "meeting-id-123",
-                "1",
-                "local-storage-key-abc",  // localStorageKey 존재 → 실 참여자
-                "이영희",
-                "서울시 왕십리",
-                "37.5614080",
-                "127.0379670"
-        );
+    @Nested
+    @DisplayName("모임장 첫 출발지 등록 (기존 호스트 참여자)")
+    class HostFirstLocationVote {
 
-        // when
-        locationService.createLocationVote(request);
+        @Test
+        @DisplayName("모임장이 처음 출발지 등록 시 LocationVote가 기존 Participant에 연결된다")
+        void createLocationVote_hostFirstVote_savesVoteLinkedToExistingParticipant() {
+            // given
+            String meetingId = "meeting-id-789";
+            Meeting meeting = Meeting.ofId(meetingId);
+            Participant host = Participant.hostOf(meeting, "host-key", "모임장");
+            meeting.addParticipant(host);
+            // 호스트는 아직 출발지를 등록하지 않은 상태 (locationVotes 비어있음)
 
-        // then
-        ArgumentCaptor<Participant> captor = ArgumentCaptor.forClass(Participant.class);
-        verify(participantService).save(captor.capture());
+            CreateLocationVoteRequest request = new CreateLocationVoteRequest(
+                    meetingId,
+                    "1",
+                    "host-key",
+                    "모임장",
+                    "서울시 마포구",
+                    "37.5549340",
+                    "126.9137540"
+            );
 
-        Participant savedParticipant = captor.getValue();
-        assertThat(savedParticipant.getName()).isEqualTo("이영희");
-        assertThat(savedParticipant.getLocalStorageKey()).isEqualTo("local-storage-key-abc");
-        assertThat(savedParticipant.getLocationVotes()).hasSize(1);
+            when(meetingService.get(meetingId)).thenReturn(meeting);
 
-        LocationVote locationVote = savedParticipant.getLocationVotes().get(0);
-        assertThat(locationVote.getDepartureLocation()).isEqualTo("서울시 왕십리");
-        assertThat(locationVote.getDepartureLat()).isEqualByComparingTo(new BigDecimal("37.5614080"));
-        assertThat(locationVote.getDepartureLng()).isEqualByComparingTo(new BigDecimal("127.0379670"));
+            // when
+            locationService.createLocationVote(request);
 
-        verify(locationVoteRepository, never()).save(any());
+            // then
+            verify(participantService, never()).save(any());
+            verify(locationVoteRepository).save(argThat(locationVote ->
+                    locationVote.getDepartureLocation().equals("서울시 마포구")
+            ));
+            assertThat(host.getLocationVotes()).hasSize(1);
+            assertThat(host.getLocationVotes().get(0).getDepartureLocation()).isEqualTo("서울시 마포구");
+        }
+
+        @Test
+        @DisplayName("모임장이 이미 출발지를 등록했을 때 DUPLICATE_LOCAL_STORAGE_KEY 예외가 발생한다")
+        void createLocationVote_hostAlreadyVoted_throwsDuplicateException() {
+            // given
+            String meetingId = "meeting-id-789";
+            Meeting meeting = Meeting.ofId(meetingId);
+            Participant host = Participant.hostOf(meeting, "host-key", "모임장");
+            // 호스트가 이미 출발지를 등록한 상태
+            LocationVote existingVote = LocationVote.fromByCreateLocationVoteRequest(
+                    new CreateLocationVoteRequest(meetingId, "1", "host-key", "모임장", "서울시 강남구", "37.4979502", "127.0276368")
+            );
+            host.addLocationVote(existingVote);
+            meeting.addParticipant(host);
+
+            CreateLocationVoteRequest request = new CreateLocationVoteRequest(
+                    meetingId,
+                    "1",
+                    "host-key",
+                    "모임장",
+                    "서울시 서초구",
+                    "37.4837121",
+                    "127.0324112"
+            );
+
+            when(meetingService.get(meetingId)).thenReturn(meeting);
+
+            // when & then
+            assertThatThrownBy(() -> locationService.createLocationVote(request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DUPLICATE_LOCAL_STORAGE_KEY);
+        }
     }
 
-    @Test
-    @DisplayName("실 참여자 추가 시 Meeting ID가 올바르게 세팅된다")
-    void createLocationVote_participantAdd_setsMeetingId() {
-        // given
-        CreateLocationVoteRequest request = new CreateLocationVoteRequest(
-                "meeting-id-456",
-                "1",
-                "local-storage-key-xyz",
-                "박민수",
-                "서울시 서초구",
-                "37.4837121",
-                "127.0324112"
-        );
+    @Nested
+    @DisplayName("중복 localStorageKey 예외")
+    class DuplicateLocalStorageKey {
 
-        // when
-        locationService.createLocationVote(request);
+        @Test
+        @DisplayName("일반 참여자가 이미 존재하는 localStorageKey로 요청 시 DUPLICATE_LOCAL_STORAGE_KEY 예외가 발생한다")
+        void createLocationVote_duplicateKeyForNonHost_throwsDuplicateException() {
+            // given
+            String meetingId = "meeting-id-123";
+            Meeting meeting = Meeting.ofId(meetingId);
+            Participant existingParticipant = Participant.of(meeting, "duplicate-key", "기존참여자");
+            meeting.addParticipant(existingParticipant);
 
-        // then
-        ArgumentCaptor<Participant> captor = ArgumentCaptor.forClass(Participant.class);
-        verify(participantService).save(captor.capture());
+            CreateLocationVoteRequest request = new CreateLocationVoteRequest(
+                    meetingId,
+                    "1",
+                    "duplicate-key",
+                    "새참여자",
+                    "서울시 강남구",
+                    "37.4979502",
+                    "127.0276368"
+            );
 
-        Participant savedParticipant = captor.getValue();
-        assertThat(savedParticipant.getMeeting().getId()).isEqualTo("meeting-id-456");
+            when(meetingService.get(meetingId)).thenReturn(meeting);
+
+            // when & then
+            assertThatThrownBy(() -> locationService.createLocationVote(request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DUPLICATE_LOCAL_STORAGE_KEY);
+        }
     }
 }


### PR DESCRIPTION
## Issue Number
closed #0

## As-Is
모임장이 `POST /api/locations/vote`를 `localStorageKey`와 함께 호출하면, 내부에서 새 `Participant`를 생성하려고 시도함.
모임장은 모임 생성 시 이미 `Participant`로 등록되어 있어 unique constraint 위반으로 **E409 에러** 발생 → 모임장은 출발지 등록 불가

## To-Be
`createLocationVote`에서 `localStorageKey`로 기존 참여자를 먼저 조회하는 방식으로 변경.

- 기존 참여자가 존재하고 **모임장이면서 미등록** → 기존 `Participant`에 `LocationVote`를 생성·연결하고 `locationVoteId` 반환
- 기존 참여자가 존재하지만 **일반 참여자이거나 이미 등록한 경우** → `E413` 반환
- 존재하지 않는 경우 → 기존 일반 참여자 출발지 등록 플로우 유지
- `localStorageKey` 없이 호출 → 기존 수동 출발지 입력 플로우 유지

**변경 파일**
- `Participant.java`: `addLocationVote` 접근제어자 `private` → `public`
- `LocationVoteServiceImpl.java`: `createLocationVote` 로직 수정, `MeetingRepository` → `MeetingService` (도메인 경계 준수)

## Review Request (중요)
- 코드 리뷰는 **한국어로 작성**해주세요.
- 구현 의도, 리스크, 개선 포인트 중심으로 리뷰 부탁드립니다.

## Check List
- [ ] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [ ] Assignee를 지정했나요?
- [ ] Label을 지정했나요?
- [ ] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
시간 투표 모임장 이슈(#110)와 동일한 패턴의 버그. 출발지 등록 플로우에도 동일하게 적용.

기존 `MeetingRepository` 직접 의존을 `MeetingService`로 교체하여 location 도메인 내 다른 서비스(`MidpointRecommendationServiceImpl`, `PersonalRouteQueryServiceImpl`)와 동일한 컨벤션 준수.