### PR TITLE
chore(ci): dev 브랜치 push 시 deploy 워크플로우 실행 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main  # main 브랜치에 push될 때 실행
+      - dev   # dev 브랜치에 push될 때 실행
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
## Issue Number
closed #0

## As-Is
`deploy.yml` 워크플로우가 `main` 브랜치 push 시에만 동작하여, `dev` 브랜치에 push해도 배포가 실행되지 않았습니다.

## To-Be
프로젝트 마감 기한이 얼마 남지 않아 백엔드 이슈 수정사항을 빠르게 반영해야 하는 상황입니다. 기존에는 `dev` → `main` 머지 후에만 배포가 이루어졌는데, 이 과정을 단축하기 위해 `deploy.yml`의 `on.push.branches`에 `dev`를 추가하여 `dev` 브랜치 push 시에도 즉시 배포 워크플로우가 실행되도록 수정했습니다.

## Review Request (중요)
- 코드 리뷰는 **한국어로 작성**해주세요.
- 구현 의도, 리스크, 개선 포인트 중심으로 리뷰 부탁드립니다.

## Check List
- [ ] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [ ] Assignee를 지정했나요?
- [ ] Label을 지정했나요?
- [ ] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
> ⚠️ 현재 `dev`와 `main` 양쪽 모두 Docker 이미지 태그 `latest`를 공유하므로, 두 브랜치가 동일한 서버·이미지를 사용하는 구조입니다. 추후 환경 분리가 필요하면 이미지 태그(`dev-latest` 등)와 서버 Secrets를 분리하는 작업이 필요합니다.