### PR TITLE
fix (location) : 출발지 추가시 locationPollId 넘기지 않도록 수정

### DIFF
--- a/src/main/java/com/dnd/moyeolak/domain/location/dto/CreateLocationVoteRequest.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/dto/CreateLocationVoteRequest.java
@@ -8,9 +8,6 @@ public record CreateLocationVoteRequest(
     @Schema(description = "모임 ID", example = "abc123")
     @NotBlank String meetingId,
 
-    @Schema(description = "위치 투표판 ID", example = "1")
-    @NotBlank String locationPollId,
-
     @Schema(description = "브라우저 로컬스토리지 키 (재참여 방지용)", example = "ls_key_abc123")
     String localStorageKey,
 

--- a/src/main/java/com/dnd/moyeolak/domain/location/entity/LocationVote.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/entity/LocationVote.java
@@ -77,9 +77,9 @@ public class LocationVote extends BaseEntity {
                 .build();
     }
 
-    public static LocationVote fromByCreateLocationVoteRequest(CreateLocationVoteRequest request) {
+    public static LocationVote fromByCreateLocationVoteRequest(LocationPoll locationPoll, CreateLocationVoteRequest request) {
         return LocationVote.builder()
-                .locationPoll(LocationPoll.ofId(Long.parseLong(request.locationPollId())))
+                .locationPoll(locationPoll)
                 .departureName(request.participantName())
                 .departureLocation(request.departureLocation())
                 .departureLat(new BigDecimal(request.departureLat()))

--- a/src/main/java/com/dnd/moyeolak/domain/location/service/impl/LocationVoteServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/service/impl/LocationVoteServiceImpl.java
@@ -2,11 +2,13 @@ package com.dnd.moyeolak.domain.location.service.impl;
 
 import com.dnd.moyeolak.domain.location.dto.CreateLocationVoteRequest;
 import com.dnd.moyeolak.domain.location.dto.LocationVoteResponse;
+import com.dnd.moyeolak.domain.location.entity.LocationPoll;
 import com.dnd.moyeolak.domain.location.entity.LocationVote;
 import com.dnd.moyeolak.domain.location.repository.LocationVoteRepository;
 import com.dnd.moyeolak.domain.location.service.LocationVoteService;
 import com.dnd.moyeolak.domain.meeting.dto.UpdateLocationVoteRequest;
 import com.dnd.moyeolak.domain.meeting.entity.Meeting;
+import com.dnd.moyeolak.domain.meeting.repository.MeetingRepository;
 import com.dnd.moyeolak.domain.meeting.service.MeetingService;
 import com.dnd.moyeolak.domain.participant.entity.Participant;
 import com.dnd.moyeolak.domain.participant.service.ParticipantService;
@@ -25,7 +27,7 @@ import java.util.Optional;
 @Transactional(readOnly = true)
 public class LocationVoteServiceImpl implements LocationVoteService {
 
-    private final MeetingService meetingService;
+    private final MeetingRepository meetingRepository;
     private final ParticipantService participantService;
     private final LocationVoteRepository locationVoteRepository;
 
@@ -46,14 +48,16 @@ public class LocationVoteServiceImpl implements LocationVoteService {
     @Override
     @Transactional
     public Long createLocationVote(CreateLocationVoteRequest request) {
-        LocationVote locationVote = LocationVote.fromByCreateLocationVoteRequest(request);
+        Meeting meeting = meetingRepository.findByIdWithAllAssociations(request.meetingId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));
+
+        LocationPoll locationPoll = meeting.getLocationPoll();
+        LocationVote locationVote = LocationVote.fromByCreateLocationVoteRequest(locationPoll, request);
 
         if (!StringUtils.hasText(request.localStorageKey())) {
             locationVoteRepository.save(locationVote);
             return locationVote.getId();
         }
-
-        Meeting meeting = meetingService.get(request.meetingId());
 
         Optional<Participant> existingParticipant = meeting.getParticipants().stream()
                 .filter(p -> request.localStorageKey().equals(p.getLocalStorageKey()))

--- a/src/test/java/com/dnd/moyeolak/domain/location/service/LocationVoteIntegrationTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/location/service/LocationVoteIntegrationTest.java
@@ -48,7 +48,6 @@ class LocationVoteIntegrationTest {
 
         CreateLocationVoteRequest request = new CreateLocationVoteRequest(
                 meetingId,
-                locationPollId.toString(),
                 null,
                 "홍길동",
                 "서울시 강남구",
@@ -78,7 +77,6 @@ class LocationVoteIntegrationTest {
 
         CreateLocationVoteRequest request = new CreateLocationVoteRequest(
                 meetingId,
-                locationPollId.toString(),
                 "new-local-key",
                 "김철수",
                 "서울시 홍대입구",
@@ -108,7 +106,6 @@ class LocationVoteIntegrationTest {
 
         CreateLocationVoteRequest request = new CreateLocationVoteRequest(
                 meetingId,
-                locationPollId.toString(),
                 null,
                 "홍길동",
                 "서울시 강남구",
@@ -145,7 +142,6 @@ class LocationVoteIntegrationTest {
 
         CreateLocationVoteRequest request = new CreateLocationVoteRequest(
                 meetingId,
-                locationPollId.toString(),
                 "local-storage-key-new",
                 "김철수",
                 "서울시 홍대입구",
@@ -187,7 +183,6 @@ class LocationVoteIntegrationTest {
 
         CreateLocationVoteRequest request = new CreateLocationVoteRequest(
                 meetingId,
-                locationPollId.toString(),
                 "local-storage-key-cascade",
                 "이영희",
                 "서울시 왕십리",
@@ -222,7 +217,6 @@ class LocationVoteIntegrationTest {
 
         CreateLocationVoteRequest manualRequest = new CreateLocationVoteRequest(
                 meetingId,
-                locationPollId.toString(),
                 null,
                 "수동입력자",
                 "서울시 서초구",
@@ -232,7 +226,6 @@ class LocationVoteIntegrationTest {
 
         CreateLocationVoteRequest participantRequest = new CreateLocationVoteRequest(
                 meetingId,
-                locationPollId.toString(),
                 "local-storage-key-mix",
                 "박민수",
                 "서울시 부평",
@@ -265,7 +258,6 @@ class LocationVoteIntegrationTest {
 
         CreateLocationVoteRequest request = new CreateLocationVoteRequest(
                 meetingId,
-                locationPollId.toString(),
                 "local-storage-key-delete",
                 "홍길동",
                 "서울시 강남구",
@@ -305,7 +297,6 @@ class LocationVoteIntegrationTest {
 
         CreateLocationVoteRequest createRequest = new CreateLocationVoteRequest(
                 meetingId,
-                locationPollId.toString(),
                 "local-storage-key-update",
                 "홍길동",
                 "서울시 강남구",


### PR DESCRIPTION
## Issue Number

## As-Is
<!-- 문제 상황 정의 -->
현재 출발지를 추가할 때, locationPollId를 전달받고 있는데 해당 데이터를 화면에서 가지고 있지 않음. 

## To-Be
<!-- 변경 사항 -->
출발지 추가할 때, meetingId 로만 처리하도록 수정

## Review Request (중요)
- 코드 리뷰는 **한국어로 작성**해주세요.
- 구현 의도, 리스크, 개선 포인트 중심으로 리뷰 부탁드립니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
