### PR TITLE
fix (schedule) : startTime >= endTime 역순 시간대 거부 및 에러코드 추가

### DIFF
--- a/src/main/java/com/dnd/moyeolak/domain/schedule/dto/UpdateSchedulePollRequest.java
+++ b/src/main/java/com/dnd/moyeolak/domain/schedule/dto/UpdateSchedulePollRequest.java
@@ -19,7 +19,7 @@ public record UpdateSchedulePollRequest(
         @NotEmpty List<@NotNull LocalDate> dateOptions,
 
         @Schema(
-                description = "투표 시작 시간 (HH:mm, 30분 단위만 허용, 24:00 불가 / 종료 시간보다 늦을 수 있음)",
+                description = "투표 시작 시간 (HH:mm, 30분 단위만 허용, 24:00 불가, 종료 시간보다 빨라야 함)",
                 example = "07:00",
                 pattern = "^(?:[01]\\\\d|2[0-3]):(?:00|30)$",
                 requiredMode = Schema.RequiredMode.REQUIRED
@@ -29,7 +29,7 @@ public record UpdateSchedulePollRequest(
         String startTime,
 
         @Schema(
-                description = "투표 종료 시간 (HH:mm 또는 24:00, 30분 단위만 허용, startTime과 동일 불가)",
+                description = "투표 종료 시간 (HH:mm 또는 24:00, 30분 단위만 허용, startTime보다 늦어야 함)",
                 example = "24:00",
                 pattern = "^(?:24:00|(?:[01]\\\\d|2[0-3]):(?:00|30))$",
                 requiredMode = Schema.RequiredMode.REQUIRED

--- a/src/main/java/com/dnd/moyeolak/domain/schedule/service/impl/SchedulePollServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/schedule/service/impl/SchedulePollServiceImpl.java
@@ -46,8 +46,8 @@ public class SchedulePollServiceImpl implements SchedulePollService {
         int startMinute = parseToMinuteOfDay(request.startTime(), false);
         int endMinute = parseToMinuteOfDay(request.endTime(), true);
 
-        if (startMinute == endMinute) {
-            throw new BusinessException(ErrorCode.INVALID_FORMAT);
+        if (startMinute >= endMinute) {
+            throw new BusinessException(ErrorCode.INVALID_TIME_RANGE);
         }
 
         schedulePoll.updateOptions(request.dateOptions(), startMinute, endMinute);

--- a/src/main/java/com/dnd/moyeolak/global/response/ErrorCode.java
+++ b/src/main/java/com/dnd/moyeolak/global/response/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     ODSAY_API_ERROR("E423", "대중교통 경로 조회에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     KAKAO_API_ERROR("E424", "자동차 경로 조회에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     INSUFFICIENT_LOCATION_VOTES("E425", "출발지 2개 이상 등록 시 중간지점을 확인할 수 있습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_TIME_RANGE("E426", "시작 시간은 종료 시간보다 빨라야 합니다.", HttpStatus.BAD_REQUEST),
 
     // 서버 오류
     SERVER_ERROR("E500", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/test/java/com/dnd/moyeolak/domain/schedule/service/SchedulePollServiceImplTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/schedule/service/SchedulePollServiceImplTest.java
@@ -99,16 +99,16 @@ class SchedulePollServiceImplTest {
         // when & then
         assertThatThrownBy(() -> schedulePollService.updateSchedulePoll(meetingId, request))
                 .isInstanceOf(BusinessException.class)
-                .hasMessageContaining(ErrorCode.INVALID_FORMAT.getMessage());
+                .hasMessageContaining(ErrorCode.INVALID_TIME_RANGE.getMessage());
     }
 
     @Test
-    @DisplayName("종료 시간보다 늦은 시작 시간을 허용한다")
-    void updateSchedulePoll_allowsOvernightWindow() {
+    @DisplayName("시작 시간이 종료 시간보다 늦으면 예외가 발생한다")
+    void updateSchedulePoll_throwsWhenStartIsAfterEnd() {
         // given
         String meetingId = "meeting-1";
         Meeting meeting = Meeting.of(5);
-        SchedulePoll schedulePoll = spy(SchedulePoll.defaultOf(meeting));
+        SchedulePoll schedulePoll = SchedulePoll.defaultOf(meeting);
         meeting.addPolls(schedulePoll, null);
         when(meetingRepository.findByIdWithAllAssociations(meetingId)).thenReturn(Optional.of(meeting));
 
@@ -118,11 +118,9 @@ class SchedulePollServiceImplTest {
                 "06:00"
         );
 
-        // when
-        schedulePollService.updateSchedulePoll(meetingId, request);
-
-        // then
-        verify(schedulePoll).updateOptions(eq(request.dateOptions()), eq(23 * 60 + 30), eq(6 * 60));
-        verify(scheduleVoteService).deleteOutOfRangeVotes(schedulePoll);
+        // when & then
+        assertThatThrownBy(() -> schedulePollService.updateSchedulePoll(meetingId, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.INVALID_TIME_RANGE.getMessage());
     }
 }


### PR DESCRIPTION
## Summary
- `startTime >= endTime`인 경우 기존 `INVALID_FORMAT` 대신 명확한 `INVALID_TIME_RANGE(E426)` 에러코드로 거부
- `==` 조건을 `>=` 로 변경하여 overnight(역순) 시간대도 거부
- Swagger description 문구를 실제 검증 로직에 맞게 수정
- 관련 단위 테스트 갱신

## Test plan
- [ ] `startTime: "07:00"`, `endTime: "22:00"` → 정상 통과
- [ ] `startTime: "22:30"`, `endTime: "22:30"` → `E426` 반환
- [ ] `startTime: "23:30"`, `endTime: "06:00"` → `E426` 반환
- [ ] `./gradlew test --tests "*.SchedulePollServiceImplTest"` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)