### PR TITLE
docs (schedule) : schedule 도메인 Swagger 커스텀 어노테이션 추가 및 수정

### DIFF
--- a/src/main/java/com/dnd/moyeolak/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/dnd/moyeolak/domain/schedule/controller/ScheduleController.java
@@ -1,14 +1,15 @@
 package com.dnd.moyeolak.domain.schedule.controller;
 
+import com.dnd.moyeolak.domain.schedule.docs.ConfirmSchedulePollApiDocs;
 import com.dnd.moyeolak.domain.schedule.docs.CreateScheduleVoteApiDocs;
 import com.dnd.moyeolak.domain.schedule.docs.UpdateSchedulePollApiDocs;
+import com.dnd.moyeolak.domain.schedule.docs.UpdateScheduleVoteApiDocs;
 import com.dnd.moyeolak.domain.schedule.dto.CreateScheduleVoteRequest;
 import com.dnd.moyeolak.domain.schedule.dto.UpdateSchedulePollRequest;
 import com.dnd.moyeolak.domain.schedule.dto.UpdateScheduleVoteRequest;
 import com.dnd.moyeolak.domain.schedule.service.SchedulePollService;
 import com.dnd.moyeolak.domain.schedule.service.ScheduleVoteService;
 import com.dnd.moyeolak.global.response.ApiResponse;
-import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -37,7 +38,7 @@ public class ScheduleController {
     }
 
     @PutMapping("/poll/confirm")
-    @Operation(summary = "시간 투표 확정", description = "시간 투표를 확정 짓습니다.")
+    @ConfirmSchedulePollApiDocs
     public ResponseEntity<ApiResponse<Void>> confirmSchedulePoll(
             @Parameter(description = "모임 ID", example = "abc-123", required = true)
             @RequestParam String meetingId
@@ -59,7 +60,7 @@ public class ScheduleController {
     }
 
     @PutMapping("/vote/{scheduleVoteId}")
-    @Operation(summary = "시간 투표 수정", description = "특정 시간 투표를 수정합니다.")
+    @UpdateScheduleVoteApiDocs
     public ResponseEntity<ApiResponse<Void>> updateScheduleVote(
             @PathVariable Long scheduleVoteId,
             @RequestBody UpdateScheduleVoteRequest request

--- a/src/main/java/com/dnd/moyeolak/domain/schedule/docs/ConfirmSchedulePollApiDocs.java
+++ b/src/main/java/com/dnd/moyeolak/domain/schedule/docs/ConfirmSchedulePollApiDocs.java
@@ -14,21 +14,19 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Operation(
-        summary = "일정 투표 옵션 수정",
+        summary = "시간 투표 확정",
         description = """
-                    모임의 일정 투표 옵션(날짜 목록, 시작/종료 시간)을 수정합니다.
+                    모임의 시간 투표 상태를 CONFIRMED로 변경합니다.
 
-                    **제약 조건**
-                    - `dateOptions`: 최소 1개 이상의 날짜 필수 (빈 배열 불가)
-                    - `startTime`: HH:mm 형식, 30분 단위만 허용, 24:00 불가, 종료 시간보다 빨라야 함
-                    - `endTime`: HH:mm 또는 24:00, 30분 단위만 허용, 24:00 = 자정
-                    - 범위를 벗어난 기존 참가자의 일정 투표(ScheduleVote)는 자동 삭제됩니다
+                    **주의사항**
+                    - 확정 후에는 투표 옵션 수정이 불가합니다
+                    - 모임에 일정 투표판(SchedulePoll)이 존재해야 합니다
                     """
 )
 @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
-                description = "수정 성공",
+                description = "확정 성공",
                 content = @Content(
                         mediaType = "application/json",
                         examples = @ExampleObject(
@@ -40,38 +38,6 @@ import java.lang.annotation.Target;
                                         }
                                         """
                         )
-                )
-        ),
-        @ApiResponse(
-                responseCode = "400",
-                description = "잘못된 요청",
-                content = @Content(
-                        mediaType = "application/json",
-                        examples = {
-                                @ExampleObject(
-                                        name = "날짜 목록 비어있음",
-                                        summary = "dateOptions 빈 배열",
-                                        value = """
-                                                {
-                                                  "code": "E103",
-                                                  "message": "유효성 검증 실패",
-                                                  "data": {
-                                                    "dateOptions": "날짜 목록은 최소 1개 이상이어야 합니다"
-                                                  }
-                                                }
-                                                """
-                                ),
-                                @ExampleObject(
-                                        name = "시간 범위 오류",
-                                        summary = "startTime >= endTime",
-                                        value = """
-                                                {
-                                                  "code": "E426",
-                                                  "message": "시작 시간은 종료 시간보다 빨라야 합니다."
-                                                }
-                                                """
-                                )
-                        }
                 )
         ),
         @ApiResponse(
@@ -102,5 +68,5 @@ import java.lang.annotation.Target;
                 )
         )
 })
-public @interface UpdateSchedulePollApiDocs {
+public @interface ConfirmSchedulePollApiDocs {
 }

--- a/src/main/java/com/dnd/moyeolak/domain/schedule/docs/UpdateScheduleVoteApiDocs.java
+++ b/src/main/java/com/dnd/moyeolak/domain/schedule/docs/UpdateScheduleVoteApiDocs.java
@@ -1,0 +1,72 @@
+package com.dnd.moyeolak.domain.schedule.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+        summary = "시간 투표 수정",
+        description = """
+                    참여자의 시간 투표를 수정합니다.
+
+                    **주의사항**
+                    - `votedDates`는 30분 단위로 전송 (예: 09:00, 09:30, 10:00)
+                    - 시간은 ISO-8601 형식 + Asia/Seoul 기준
+                    """
+)
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "수정 성공",
+                content = @Content(
+                        mediaType = "application/json",
+                        examples = @ExampleObject(
+                                name = "성공 응답",
+                                value = """
+                                        {
+                                          "code": "S100",
+                                          "message": "요청이 성공적으로 처리되었습니다."
+                                        }
+                                        """
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "404",
+                description = "참여자 또는 시간 투표를 찾을 수 없음",
+                content = @Content(
+                        mediaType = "application/json",
+                        examples = {
+                                @ExampleObject(
+                                        name = "참여자 없음",
+                                        value = """
+                                                {
+                                                  "code": "E414",
+                                                  "message": "참여자가 존재하지 않습니다."
+                                                }
+                                                """
+                                ),
+                                @ExampleObject(
+                                        name = "시간 투표 없음",
+                                        value = """
+                                                {
+                                                  "code": "E416",
+                                                  "message": "시간 응답이 존재하지 않습니다."
+                                                }
+                                                """
+                                )
+                        }
+                )
+        )
+})
+public @interface UpdateScheduleVoteApiDocs {
+}


### PR DESCRIPTION
## Issue Number
closed #0

## As-Is
- `PUT /api/schedules/poll/confirm`, `PUT /api/schedules/vote/{scheduleVoteId}` 엔드포인트에 인라인 `@Operation` 사용 (커스텀 docs 어노테이션 패턴 미적용)
- `UpdateSchedulePollApiDocs`의 `startTime` 설명이 실제 검증 로직과 모순 ("종료 시간보다 늦을 수 있음" vs 실제: 빨라야 함)
- `UpdateSchedulePollApiDocs`에 응답 예시(`@ExampleObject`) 없음 — `CreateScheduleVoteApiDocs`와 스타일 불일치
- `@io.swagger.v3.oas.annotations.responses.ApiResponse` 전체 경로 사용 (import 불일치)

## To-Be
- `ConfirmSchedulePollApiDocs`, `UpdateScheduleVoteApiDocs` 커스텀 어노테이션 신규 생성
- `ScheduleController`에서 인라인 `@Operation` → 커스텀 어노테이션으로 교체, 미사용 import 제거
- `UpdateSchedulePollApiDocs` 수정
  - `startTime` 설명 오류 수정 ("빨라야 함"으로 정정)
  - "기존 투표 유지" → "범위 벗어난 투표 자동 삭제" (실제 동작 반영)
  - 200(S100), 400(E103/E426), 404(E410/E411) 응답 예시 추가
  - `ApiResponse` 단축 import 통일

## Review Request (중요)
- 코드 리뷰는 **한국어로 작성**해주세요.
- 구현 의도, 리스크, 개선 포인트 중심으로 리뷰 부탁드립니다.

## Check List
- [ ] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [ ] Assignee를 지정했나요?
- [ ] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
변경 파일 목록:
- `docs/UpdateSchedulePollApiDocs.java` — 수정
- `docs/ConfirmSchedulePollApiDocs.java` — 신규
- `docs/UpdateScheduleVoteApiDocs.java` — 신규
- `controller/ScheduleController.java` — 커스텀 어노테이션 적용