### PR TITLE
feat: list location votes by meeting

### DIFF
--- a/src/main/java/com/dnd/moyeolak/domain/location/controller/LocationController.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/controller/LocationController.java
@@ -86,12 +86,12 @@ public class LocationController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @GetMapping("/poll/{locationPollId}/votes")
+    @GetMapping("/vote")
     @ListLocationVoteApiDocs
     public ResponseEntity<ApiResponse<?>> listLocationVote(
-            @Parameter(description = "위치 투표판 ID", example = "1", required = true)
-            @PathVariable Long locationPollId) {
-        List<LocationVoteResponse> listLocationVote = locationVoteService.listLocationVote(locationPollId);
+            @Parameter(description = "모임 ID", example = "test-meeting-001", required = true)
+            @RequestParam String meetingId) {
+        List<LocationVoteResponse> listLocationVote = locationVoteService.listLocationVote(meetingId);
         return ResponseEntity.ok(ApiResponse.success(listLocationVote));
     }
 

--- a/src/main/java/com/dnd/moyeolak/domain/location/docs/ListLocationVoteApiDocs.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/docs/ListLocationVoteApiDocs.java
@@ -15,7 +15,7 @@ import java.lang.annotation.Target;
 @Operation(
         summary = "출발지 투표 조회",
         description = """
-                    장소 조율 시 등록된 출발지 투표 목록을 조회합니다.
+                    장소 조율 시 등록된 출발지 투표 목록을 조회합니다. 모임 ID를 쿼리 파라미터(`meetingId`)로 전달하면 자동으로 해당 모임의 위치 투표판을 찾아줍니다.
 
                     ### 사용 시점
                     - 장소 투표 현황 페이지에서 참가자들의 출발지를 표시할 때

--- a/src/main/java/com/dnd/moyeolak/domain/location/service/LocationVoteService.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/service/LocationVoteService.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface LocationVoteService {
 
-    List<LocationVoteResponse> listLocationVote(Long locationPollId);
+    List<LocationVoteResponse> listLocationVote(String meetingId);
 
     Long createLocationVote(CreateLocationVoteRequest createLocationVoteRequest);
 

--- a/src/main/java/com/dnd/moyeolak/domain/location/service/impl/LocationVoteServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/service/impl/LocationVoteServiceImpl.java
@@ -9,7 +9,6 @@ import com.dnd.moyeolak.domain.location.service.LocationVoteService;
 import com.dnd.moyeolak.domain.meeting.dto.UpdateLocationVoteRequest;
 import com.dnd.moyeolak.domain.meeting.entity.Meeting;
 import com.dnd.moyeolak.domain.meeting.repository.MeetingRepository;
-import com.dnd.moyeolak.domain.meeting.service.MeetingService;
 import com.dnd.moyeolak.domain.participant.entity.Participant;
 import com.dnd.moyeolak.domain.participant.service.ParticipantService;
 import com.dnd.moyeolak.global.exception.BusinessException;
@@ -32,9 +31,19 @@ public class LocationVoteServiceImpl implements LocationVoteService {
     private final LocationVoteRepository locationVoteRepository;
 
     @Override
-    public List<LocationVoteResponse> listLocationVote(Long locationPollId) {
-        return locationVoteRepository.findByLocationPoll_Id(locationPollId)
-                .stream().map(LocationVoteResponse::from).toList();
+    public List<LocationVoteResponse> listLocationVote(String meetingId) {
+        Meeting meeting = meetingRepository.findByIdWithAllAssociations(meetingId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));
+
+        LocationPoll locationPoll = meeting.getLocationPoll();
+        if (locationPoll == null) {
+            throw new BusinessException(ErrorCode.LOCATION_POLL_NOT_FOUND);
+        }
+
+        return locationVoteRepository.findByLocationPoll_Id(locationPoll.getId())
+                .stream()
+                .map(LocationVoteResponse::from)
+                .toList();
     }
 
     @Override


### PR DESCRIPTION
## Issue Number
closed #0

## As-Is
- 출발지 투표 조회 API가 `locationPollId` path param에 의존해 FE/QA가 실사용할 수 없었음
- `locationPollId`는 응답에 노출되지 않아 모임별 투표 현황 확인이 막혀 있었음

## To-Be
- `GET /api/locations/vote?meetingId=...`로 모임 ID 기반 조회를 지원하고 서비스에서 모임/투표판 검증 수행
- Swagger 문서와 회귀 테스트를 갱신해 계약 변경을 명시하고 예외 케이스를 커버

## Review Request (중요)
- location 컨트롤러/서비스 경로 변경이 기존 클라이언트와 충돌하지 않는지 집중적으로 봐주세요.
- meeting 조회 이후 locationPoll null 케이스 처리가 충분한지도 확인 부탁드립니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [ ] Assignee를 지정했나요?
- [ ] Label을 지정했나요?
- [ ] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
- `.claude/` 하위 문서는 gitignore라 PR에는 포함되지 않았습니다.
