### PR TITLE
fix (location) : NearbyPlace 캐시 조회 시 LazyInitializationException 수정

### DIFF
--- a/src/main/java/com/dnd/moyeolak/domain/location/repository/NearbyPlaceRepository.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/repository/NearbyPlaceRepository.java
@@ -2,6 +2,8 @@ package com.dnd.moyeolak.domain.location.repository;
 
 import com.dnd.moyeolak.domain.location.entity.NearbyPlace;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
@@ -9,7 +11,8 @@ import java.util.List;
 
 public interface NearbyPlaceRepository extends JpaRepository<NearbyPlace, Long> {
 
-    List<NearbyPlace> findByBaseLatitudeAndBaseLongitude(BigDecimal baseLatitude, BigDecimal baseLongitude);
+    @Query("SELECT DISTINCT np FROM NearbyPlace np LEFT JOIN FETCH np.nearbyPlaceHours WHERE np.baseLatitude = :lat AND np.baseLongitude = :lng")
+    List<NearbyPlace> findByBaseLatitudeAndBaseLongitude(@Param("lat") BigDecimal baseLatitude, @Param("lng") BigDecimal baseLongitude);
 
     @Transactional
     void deleteByBaseLatitudeAndBaseLongitude(BigDecimal baseLatitude, BigDecimal baseLongitude);


### PR DESCRIPTION
## Summary

- `NearbyPlaceRepository.findByBaseLatitudeAndBaseLongitude`에 `@Query` + `LEFT JOIN FETCH np.nearbyPlaceHours` 추가
- `DISTINCT`로 JOIN 시 발생하는 중복 row 제거
- `@Transactional` 없는 서비스에서 캐시 히트 시 세션 종료 후 LAZY 컬렉션 접근으로 발생하던 `LazyInitializationException` 해결

## 버그 상세

`GET /api/locations/nearby-place-search` 호출 시:
- **최초 호출(캐시 없음)**: 외부 API로 엔티티를 메모리에서 직접 생성 → 정상 동작
- **이후 모든 호출(캐시 있음)**: DB에서 `NearbyPlace`만 조회 후 세션 종료 → `buildResponse`에서 `place.getNearbyPlaceHours()` 접근 시 세션 없음 → 💥

캐시 유효기간(30일) 동안 해당 좌표의 모든 요청이 500으로 실패하며, 요청마다 스택 트레이스가 반복 로깅되어 서버 성능 저하 유발.

## Test plan

- [ ] `GET /api/locations/nearby-place-search?latitude={위도}&longitude={경도}` 최초 호출 → 정상 응답 확인
- [ ] 동일 좌표로 재호출 (캐시 히트 경로) → 200 정상 응답 확인 (기존엔 500)
- [ ] 응답 내 각 장소의 영업시간 정보(`businessStatus`) 정상 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)