### PR TITLE
fix (location) : 위치 투표 변경 시 중간지점 추천 캐시 무효화

### DIFF
--- a/src/main/java/com/dnd/moyeolak/domain/location/service/impl/LocationVoteServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/service/impl/LocationVoteServiceImpl.java
@@ -14,6 +14,7 @@ import com.dnd.moyeolak.domain.participant.service.ParticipantService;
 import com.dnd.moyeolak.global.exception.BusinessException;
 import com.dnd.moyeolak.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -48,6 +49,7 @@ public class LocationVoteServiceImpl implements LocationVoteService {
 
     @Override
     @Transactional
+    @CacheEvict(value = "midpointRecommendations", allEntries = true)
     public void updateLocationVote(Long locationVoteId, UpdateLocationVoteRequest request) {
         LocationVote locationVote = locationVoteRepository.findById(locationVoteId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.LOCATION_VOTE_NOT_FOUND));
@@ -56,6 +58,7 @@ public class LocationVoteServiceImpl implements LocationVoteService {
 
     @Override
     @Transactional
+    @CacheEvict(value = "midpointRecommendations", allEntries = true)
     public Long createLocationVote(CreateLocationVoteRequest request) {
         Meeting meeting = meetingRepository.findByIdWithAllAssociations(request.meetingId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));
@@ -93,6 +96,7 @@ public class LocationVoteServiceImpl implements LocationVoteService {
 
     @Override
     @Transactional
+    @CacheEvict(value = "midpointRecommendations", allEntries = true)
     public void deleteLocationVote(Long locationVoteId) {
         LocationVote locationVote = locationVoteRepository.findById(locationVoteId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.LOCATION_VOTE_NOT_FOUND));


### PR DESCRIPTION
## Summary
- 출발지(LocationVote) 추가·수정·삭제 후 중간지점 추천 API를 재호출해도 이전 결과가 반환되는 캐시 버그 수정
- `LocationVoteServiceImpl`의 `createLocationVote`, `updateLocationVote`, `deleteLocationVote`에 `@CacheEvict(value = "midpointRecommendations", allEntries = true)` 추가
- 위치 투표 데이터가 변경될 때마다 `midpointRecommendations` 캐시 전체를 무효화하여 항상 최신 출발지 기준으로 중간지점을 계산

## Test plan
- [ ] 출발지 2개 등록 → 중간지점 추천 조회 (정상 결과 캐싱 확인)
- [ ] 출발지 1개 추가 → 중간지점 추천 재조회 시 새 출발지 반영된 결과 반환 확인
- [ ] 출발지 수정/삭제 후 재조회 시 캐시가 무효화되어 최신 결과 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)