### PR TITLE
chore (infra) : AWS 테라폼 인프라 및 배포 파이프라인 구축

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,93 +1,125 @@
-name: Deploy to Naver Cloud
+name: Deploy to AWS
 
 on:
   push:
     branches:
-      - main  # main 브랜치에 push될 때 실행
-      - dev   # dev 브랜치에 push될 때 실행
+      - main
+      - dev
+
+env:
+  AWS_REGION: ap-northeast-2
+  ECR_REPOSITORY: moyeolak-backend
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
 
     steps:
-    # 1. 코드 체크아웃
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    # 2. JDK 25 설치
-    - name: Set up JDK 25
-      uses: actions/setup-java@v4
-      with:
-        java-version: '25'
-        distribution: 'temurin'
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: gradle
 
-    # 3. Gradle 빌드 (실행 권한 부여)
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
+      - name: Build with Gradle
+        run: |
+          chmod +x gradlew
+          ./gradlew clean build -x test
 
-    # 4. Spring Boot 애플리케이션 빌드
-    - name: Build with Gradle
-      run: ./gradlew clean build -x test
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
 
-    # 5. Docker 이미지 빌드
-    - name: Build Docker image
-      run: |
-        docker build -t ${{ secrets.NCP_REGISTRY_URL }}/moyeorak-backend:latest \
-          -t ${{ secrets.NCP_REGISTRY_URL }}/moyeorak-backend:${{ github.sha }} .
+      - name: Login to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
 
-    # 6. Naver Cloud Container Registry 로그인
-    - name: Login to NCP Container Registry
-      run: |
-        echo ${{ secrets.NCP_REGISTRY_PASSWORD }} | docker login ${{ secrets.NCP_REGISTRY_URL }} \
-          -u ${{ secrets.NCP_REGISTRY_USERNAME }} --password-stdin
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-    # 7. Docker 이미지 Push
-    - name: Push Docker image
-      run: |
-        docker push ${{ secrets.NCP_REGISTRY_URL }}/moyeorak-backend:latest
-        docker push ${{ secrets.NCP_REGISTRY_URL }}/moyeorak-backend:${{ github.sha }}
+      # Dockerfile.prod는 COPY만 수행하므로 QEMU 없이 arm64 빌드 가능
+      - name: Build and push image (arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.prod
+          platforms: linux/arm64
+          push: true
+          tags: |
+            ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest
+            ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
 
-    # 8. 모니터링 설정 파일 서버에 전송
-    - name: Copy monitoring configs to server
-      uses: appleboy/scp-action@v0.1.7
-      with:
-        host: ${{ secrets.NCP_SERVER_HOST }}
-        username: ${{ secrets.NCP_SERVER_USERNAME }}
-        password: ${{ secrets.NCP_SERVER_PASSWORD }}
-        source: "monitoring/,docker-compose.monitoring.yml"
-        target: "/app/moyeorak"
+      - name: Get runner public IP
+        id: runner-ip
+        run: echo "ipv4=$(curl -s https://checkip.amazonaws.com)" >> "$GITHUB_OUTPUT"
 
-    # 9. 서버에 SSH 접속하여 배포
-    - name: Deploy to server
-      uses: appleboy/ssh-action@v1.0.0
-      with:
-        host: ${{ secrets.NCP_SERVER_HOST }}
-        username: ${{ secrets.NCP_SERVER_USERNAME }}
-        password: ${{ secrets.NCP_SERVER_PASSWORD }}
-        script: |
-          cd /app/moyeorak
+      - name: Open SSH port for runner
+        run: |
+          aws ec2 authorize-security-group-ingress \
+            --group-id ${{ secrets.AWS_SG_ID }} \
+            --protocol tcp --port 22 \
+            --cidr ${{ steps.runner-ip.outputs.ipv4 }}/32
 
-          # Container Registry 로그인
-          echo ${{ secrets.NCP_REGISTRY_PASSWORD }} | docker login ${{ secrets.NCP_REGISTRY_URL }} \
-            -u ${{ secrets.NCP_REGISTRY_USERNAME }} --password-stdin
+      - name: Copy deploy files to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: "infra/deploy/docker-compose.prod.yml,infra/deploy/Caddyfile"
+          target: /app/moyeolak
+          strip_components: 2
 
-          # 최신 이미지 Pull
-          docker pull ${{ secrets.NCP_REGISTRY_URL }}/moyeorak-backend:latest
+      - name: Copy monitoring configs to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: "monitoring/"
+          target: /app/moyeolak
 
-          # 기존 backend 컨테이너 중지 및 제거
-          docker-compose down backend
+      - name: Copy postgis init script to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: "src/main/resources/postgis-init.sql"
+          target: /app/moyeolak
+          strip_components: 3
 
-          # 새 backend 컨테이너 시작
-          docker-compose up -d backend
+      - name: Deploy on server
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            set -e
+            cd /app/moyeolak
 
-          # 모니터링 스택 시작 (이미 실행 중이면 유지)
-          GRAFANA_ADMIN_USER=${{ secrets.GRAFANA_ADMIN_USER }} \
-          GRAFANA_ADMIN_PASSWORD=${{ secrets.GRAFANA_ADMIN_PASSWORD }} \
-          docker-compose -f docker-compose.monitoring.yml up -d
+            aws ecr get-login-password --region ap-northeast-2 \
+              | docker login --username AWS --password-stdin ${{ steps.ecr-login.outputs.registry }}
 
-          # 사용하지 않는 이미지 정리
-          docker image prune -f
+            docker compose -f docker-compose.prod.yml pull backend
+            docker compose -f docker-compose.prod.yml up -d
+            docker image prune -f
 
-          echo "Deployment completed!"
-          docker ps | grep moyeorak
+            echo "Deployment completed!"
+            docker ps --format '{{.Names}}\t{{.Status}}'
+
+      - name: Close SSH port
+        if: always()
+        run: |
+          aws ec2 revoke-security-group-ingress \
+            --group-id ${{ secrets.AWS_SG_ID }} \
+            --protocol tcp --port 22 \
+            --cidr ${{ steps.runner-ip.outputs.ipv4 }}/32

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,10 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Terraform ###
+infra/terraform/.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+!*.tfvars.example

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,12 @@
+# CI에서 빌드된 JAR를 담는 런타임 전용 이미지
+# 전제: ./gradlew build 로 build/libs/*.jar 생성 후 docker build
+# COPY만 수행하므로 QEMU 없이 arm64 크로스 빌드 가능
+FROM eclipse-temurin:25-jre
+
+WORKDIR /app
+
+COPY build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/infra/deploy/.env.example
+++ b/infra/deploy/.env.example
@@ -1,0 +1,22 @@
+# EC2 /app/moyeolak/.env 로 복사 후 실제 값 입력 (git 미추적)
+DOMAIN=api.example.com
+ECR_REGISTRY=123456789012.dkr.ecr.ap-northeast-2.amazonaws.com
+
+DB_NAME=moyeolak
+DB_USERNAME=moyeolak
+DB_PASSWORD=change-me
+MYSQL_ROOT_PASSWORD=change-me
+
+POSTGIS_DB_NAME=moyeolak_spatial
+POSTGIS_USERNAME=moyeolak
+POSTGIS_PASSWORD=change-me
+
+# 최초 기동 시에만 create, 스키마 생성 후 none으로 변경
+JPA_DDL_AUTO=none
+
+KAKAO_API_KEY=change-me
+ODSAY_API_KEY=change-me
+GOOGLE_API_KEY=change-me
+
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=change-me

--- a/infra/deploy/Caddyfile
+++ b/infra/deploy/Caddyfile
@@ -1,0 +1,3 @@
+{$DOMAIN} {
+	reverse_proxy backend:8080
+}

--- a/infra/deploy/docker-compose.prod.yml
+++ b/infra/deploy/docker-compose.prod.yml
@@ -1,0 +1,160 @@
+# EC2 /app/moyeolak/ 에서 실행. 변수는 같은 디렉터리의 .env에서 공급.
+# 모니터링 활성화: docker compose -f docker-compose.prod.yml --profile monitoring up -d
+services:
+  caddy:
+    image: caddy:2-alpine
+    container_name: moyeolak-caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      DOMAIN: ${DOMAIN}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - backend
+
+  backend:
+    image: ${ECR_REGISTRY}/moyeolak-backend:latest
+    container_name: moyeolak-backend
+    restart: unless-stopped
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      DB_HOST: mysql
+      DB_PORT: "3306"
+      DB_NAME: ${DB_NAME}
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+      POSTGIS_HOST: postgis
+      POSTGIS_PORT: "5432"
+      POSTGIS_DB_NAME: ${POSTGIS_DB_NAME}
+      POSTGIS_USERNAME: ${POSTGIS_USERNAME}
+      POSTGIS_PASSWORD: ${POSTGIS_PASSWORD}
+      JPA_DDL_AUTO: ${JPA_DDL_AUTO:-none}
+      KAKAO_API_KEY: ${KAKAO_API_KEY}
+      ODSAY_API_KEY: ${ODSAY_API_KEY}
+      GOOGLE_API_KEY: ${GOOGLE_API_KEY}
+      # 2GB 인스턴스에서 힙 폭주 방지
+      JAVA_TOOL_OPTIONS: "-XX:MaxRAMPercentage=50.0"
+    volumes:
+      - ./logs:/logs
+    depends_on:
+      mysql:
+        condition: service_healthy
+      postgis:
+        condition: service_healthy
+
+  mysql:
+    image: mysql:8.0
+    container_name: moyeolak-mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USERNAME}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+      TZ: Asia/Seoul
+    volumes:
+      - mysql_data:/var/lib/mysql
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  postgis:
+    # 공식 postgis/postgis는 amd64 전용이라 arm64(t4g)에서는 imresamu 빌드 사용
+    image: imresamu/postgis:15-3.5
+    container_name: moyeolak-postgis
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGIS_DB_NAME}
+      POSTGRES_USER: ${POSTGIS_USERNAME}
+      POSTGRES_PASSWORD: ${POSTGIS_PASSWORD}
+    volumes:
+      - ./postgis-init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGIS_USERNAME} -d ${POSTGIS_DB_NAME}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  # ---------- 모니터링 (기본 비활성, --profile monitoring) ----------
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    profiles: ["monitoring"]
+    restart: unless-stopped
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=15d'
+      - '--web.enable-lifecycle'
+
+  loki:
+    image: grafana/loki:latest
+    container_name: loki
+    profiles: ["monitoring"]
+    restart: unless-stopped
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./monitoring/loki/loki-config.yml:/etc/loki/loki-config.yml:ro
+      - loki-data:/loki
+    command: -config.file=/etc/loki/loki-config.yml
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    profiles: ["monitoring"]
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      - prometheus
+      - loki
+
+  node-exporter:
+    image: prom/node-exporter:latest
+    container_name: node-exporter
+    profiles: ["monitoring"]
+    restart: unless-stopped
+    ports:
+      - "9100:9100"
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.sysfs=/host/sys'
+      - '--path.rootfs=/rootfs'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+
+volumes:
+  caddy_data:
+  caddy_config:
+  mysql_data:
+  pgdata:
+  prometheus-data:
+  loki-data:
+  grafana-data:

--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.53.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:UFEhEEFJcR/pAOZcwdR11gN9W3X8VwvSl1IS0vbj2G0=",
+    "zh:0757ce9d5a30e8225521857924f5d6c49e5885fd9e309e56193c9c9920b3f8f0",
+    "zh:10ddb3a20e0779788e8002bc67d184eb166dec70f9d07220bfc55e15c3e5e206",
+    "zh:1e943f59a8c3f3b04f09fd5d967fef2518e0ce3ec4959e31f5d7f820660e8524",
+    "zh:21d55ad3b28f48c6dd34faceeb1fd1fe2ec3b1aaecfc5eb0e0841884f6520d69",
+    "zh:2e551bc0ff29ea608a99f63d899afbdf2f23c14035f27dc0c0bdca60209d9575",
+    "zh:581db963564364200426f2a4be866470a975cde6a4bd6fd09362ec2bab119cbb",
+    "zh:71a7abc88e16ccbe4410fc4966bd35fae9e0161c1385a9b3c19800e3db626b01",
+    "zh:8767767776c45590d4cc74b4c37f6377e05ce75039a9c2e834de0bbcc29f7a1a",
+    "zh:99c8e37beb9b1017f67c41e402031559b745fa797848f1a4ef8b40421dee3f05",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ba1477eda2f3ee51846492449338146f80806088d2952c08c2f8af874550a75d",
+    "zh:c389f68ba4d39fa2bf8a54d4af7f7b2132da2a964c260892c1dd1a89b67e61f8",
+    "zh:d7381490a637a1fa45769d0ee6b3e0578cce488d078077ec63d9090113784f2a",
+    "zh:df3b82fb1a675fc6548fac2fff10a8741efa5bcb5a53d01d8f0659179a2f717f",
+    "zh:e5d78b2ac3dc5477cf21d7cd4c8b9e3d944ff091e90b62c1b2ea9cc7c7eef57c",
+    "zh:fd224078287c6d82de2ec30ea03d3d550c2c554e372b234f7a6ac2b07c23dba0",
+  ]
+}

--- a/infra/terraform/ec2.tf
+++ b/infra/terraform/ec2.tf
@@ -1,0 +1,42 @@
+# Ubuntu 24.04 LTS ARM64 최신 AMI
+data "aws_ssm_parameter" "ubuntu_arm64" {
+  name = "/aws/service/canonical/ubuntu/server/24.04/stable/current/arm64/hvm/ebs-gp3/ami-id"
+}
+
+resource "aws_key_pair" "admin" {
+  key_name   = "${var.project}-admin"
+  public_key = file(pathexpand(var.ssh_public_key_path))
+}
+
+resource "aws_instance" "app" {
+  ami                    = data.aws_ssm_parameter.ubuntu_arm64.value
+  instance_type          = var.instance_type
+  subnet_id              = aws_subnet.public.id
+  vpc_security_group_ids = [aws_security_group.app.id]
+  iam_instance_profile   = aws_iam_instance_profile.ec2.name
+  key_name               = aws_key_pair.admin.key_name
+  user_data              = file("${path.module}/user_data.sh")
+
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = var.root_volume_size
+  }
+
+  lifecycle {
+    # AMI 업데이트로 인한 의도치 않은 인스턴스 재생성 방지
+    ignore_changes = [ami]
+  }
+
+  tags = { Name = "${var.project}-app" }
+}
+
+resource "aws_eip" "app" {
+  domain = "vpc"
+
+  tags = { Name = "${var.project}-eip" }
+}
+
+resource "aws_eip_association" "app" {
+  instance_id   = aws_instance.app.id
+  allocation_id = aws_eip.app.id
+}

--- a/infra/terraform/ecr.tf
+++ b/infra/terraform/ecr.tf
@@ -1,0 +1,23 @@
+resource "aws_ecr_repository" "backend" {
+  name                 = "${var.project}-backend"
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
+}
+
+# 프리티어(500MB) 유지를 위해 최근 5개 이미지만 보관
+resource "aws_ecr_lifecycle_policy" "backend" {
+  repository = aws_ecr_repository.backend.name
+
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "keep last 5 images"
+      selection = {
+        tagStatus   = "any"
+        countType   = "imageCountMoreThan"
+        countNumber = 5
+      }
+      action = { type = "expire" }
+    }]
+  })
+}

--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -1,0 +1,73 @@
+# ---- EC2 인스턴스 프로파일: ECR pull + SSM 접속 ----
+resource "aws_iam_role" "ec2" {
+  name = "${var.project}-ec2-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecr_read" {
+  role       = aws_iam_role.ec2.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.ec2.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "ec2" {
+  name = "${var.project}-ec2-profile"
+  role = aws_iam_role.ec2.name
+}
+
+# ---- GitHub Actions 배포 사용자: ECR push + SG 임시 개방 ----
+resource "aws_iam_user" "github_actions" {
+  name = "${var.project}-github-actions"
+}
+
+resource "aws_iam_user_policy" "github_actions" {
+  name = "${var.project}-github-actions-deploy"
+  user = aws_iam_user.github_actions.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "EcrAuth"
+        Effect   = "Allow"
+        Action   = ["ecr:GetAuthorizationToken"]
+        Resource = "*"
+      },
+      {
+        Sid    = "EcrPush"
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:BatchGetImage",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload",
+          "ecr:PutImage"
+        ]
+        Resource = aws_ecr_repository.backend.arn
+      },
+      {
+        Sid    = "TemporarySshAccess"
+        Effect = "Allow"
+        Action = [
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:RevokeSecurityGroupIngress"
+        ]
+        Resource = aws_security_group.app.arn
+      }
+    ]
+  })
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+
+  backend "s3" {
+    bucket       = "moyeolak-tfstate-apne2"
+    key          = "prod/terraform.tfstate"
+    region       = "ap-northeast-2"
+    encrypt      = true
+    use_lockfile = true
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project   = var.project
+      ManagedBy = "terraform"
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}

--- a/infra/terraform/network.tf
+++ b/infra/terraform/network.tf
@@ -1,0 +1,38 @@
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = { Name = "${var.project}-vpc" }
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "${var.aws_region}a"
+  map_public_ip_on_launch = true
+
+  tags = { Name = "${var.project}-public-a" }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = { Name = "${var.project}-igw" }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = { Name = "${var.project}-public-rt" }
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,23 @@
+output "eip_public_ip" {
+  description = "도메인 A레코드 대상 / GH secret EC2_HOST"
+  value       = aws_eip.app.public_ip
+}
+
+output "security_group_id" {
+  description = "GH secret AWS_SG_ID"
+  value       = aws_security_group.app.id
+}
+
+output "ecr_repository_url" {
+  description = "백엔드 이미지 리포지토리 URL"
+  value       = aws_ecr_repository.backend.repository_url
+}
+
+output "github_actions_user" {
+  description = "액세스 키 발급 대상 IAM 사용자"
+  value       = aws_iam_user.github_actions.name
+}
+
+output "instance_id" {
+  value = aws_instance.app.id
+}

--- a/infra/terraform/security.tf
+++ b/infra/terraform/security.tf
@@ -1,0 +1,43 @@
+# GitHub Actions가 배포 시 러너 IP의 22번 규칙을 일시 추가/회수하므로
+# 인라인 ingress 블록 대신 별도 rule 리소스를 사용한다 (임시 규칙과 충돌 방지)
+resource "aws_security_group" "app" {
+  name        = "${var.project}-app-sg"
+  description = "moyeolak app server"
+  vpc_id      = aws_vpc.main.id
+
+  tags = { Name = "${var.project}-app-sg" }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "http" {
+  security_group_id = aws_security_group.app.id
+  description       = "HTTP (Lets Encrypt + redirect)"
+  from_port         = 80
+  to_port           = 80
+  ip_protocol       = "tcp"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "https" {
+  security_group_id = aws_security_group.app.id
+  description       = "HTTPS"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "ssh_admin" {
+  security_group_id = aws_security_group.app.id
+  description       = "SSH from admin IP"
+  from_port         = 22
+  to_port           = 22
+  ip_protocol       = "tcp"
+  cidr_ipv4         = var.my_ip
+}
+
+resource "aws_vpc_security_group_egress_rule" "all" {
+  security_group_id = aws_security_group.app.id
+  description       = "Allow all outbound"
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+}

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -1,0 +1,4 @@
+# 실제 값은 terraform.tfvars에 작성 (git 미추적)
+my_ip               = "1.2.3.4/32"
+ssh_public_key_path = "~/.ssh/moyeolak-aws.pub"
+# instance_type     = "t4g.medium"  # 모니터링 활성화 시 주석 해제

--- a/infra/terraform/user_data.sh
+++ b/infra/terraform/user_data.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# EC2 최초 부팅 시 1회 실행
+set -euxo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update -y
+apt-get install -y docker.io docker-compose-v2
+systemctl enable --now docker
+usermod -aG docker ubuntu
+
+# ECR 로그인용 AWS CLI (자격증명은 인스턴스 프로파일)
+snap install aws-cli --classic
+
+# t4g.small(2GB) 메모리 보완용 스왑 2GB
+fallocate -l 2G /swapfile
+chmod 600 /swapfile
+mkswap /swapfile
+swapon /swapfile
+echo '/swapfile none swap sw 0 0' >> /etc/fstab
+
+# 앱 디렉터리
+mkdir -p /app/moyeolak/logs
+chown -R ubuntu:ubuntu /app/moyeolak

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "aws_region" {
+  description = "AWS 리전"
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "project" {
+  description = "리소스 이름 접두사"
+  type        = string
+  default     = "moyeolak"
+}
+
+variable "instance_type" {
+  description = "EC2 인스턴스 타입 (모니터링 활성화 시 t4g.medium으로 변경)"
+  type        = string
+  default     = "t4g.small"
+}
+
+variable "my_ip" {
+  description = "SSH(22) 허용 CIDR. 예: 1.2.3.4/32"
+  type        = string
+}
+
+variable "ssh_public_key_path" {
+  description = "EC2 key pair로 등록할 SSH 공개키 경로"
+  type        = string
+  default     = "~/.ssh/moyeolak-aws.pub"
+}
+
+variable "root_volume_size" {
+  description = "루트 EBS(gp3) 크기 GB"
+  type        = number
+  default     = 30
+}


### PR DESCRIPTION
## 개요

NCP 기반 배포를 AWS로 전환하기 위한 인프라 코드(Terraform) 및 배포 파이프라인 변경입니다.

## 주요 변경사항

### Terraform (`infra/terraform/`)
- 전용 VPC + 퍼블릭 서브넷 1개 (NAT 없음, 비용 $0)
- EC2 t4g.small (ARM64, Ubuntu 24.04) + EIP + 스왑 2GB
- 보안 그룹: 80/443 공개, 22는 관리자 IP만
- ECR 리포지토리 (최근 5개 이미지만 보관)
- IAM: EC2 인스턴스 프로파일(ECR pull/SSM), GitHub Actions 배포 사용자(최소 권한)
- S3 backend (state 관리)

### 배포 파일
- `Dockerfile.prod`: CI 빌드 JAR를 담는 런타임 전용 이미지 (arm64, QEMU 불필요)
- `infra/deploy/docker-compose.prod.yml`: caddy + backend + mysql + postgis (+모니터링 profile)
- `infra/deploy/Caddyfile`: Let's Encrypt 자동 HTTPS
- Redis 제외 (앱은 Caffeine 인메모리 캐시 사용)
- PostGIS는 arm64 지원 `imresamu/postgis:15-3.5` 사용

### CI/CD (`deploy.yml`)
- NCP Registry → AWS ECR
- 배포 시 러너 IP만 SSH 포트 일시 개방 후 회수
- SSH 키 기반 인증 (비밀번호 제거)

## 배포 흐름
push → Gradle 빌드 → arm64 이미지 ECR push → EC2 SSH → compose 재기동

## 참고

- 인프라는 이미 `terraform apply` 완료 (EIP: 54.116.56.79, 도메인: api.moyeorak.site)

🤖 Generated with [Claude Code](https://claude.com/claude-code)