### PR TITLE
docs(readme): DB 변경 이력 문서화

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@
 
 <br/>
 
+## 📌 문서 버전
+
+현재 README는 **PostgreSQL+PostGIS 단일 DB 전환 이후**의 구조를 기준으로 합니다.
+
+- 이전 MySQL+PostGIS 분리 구성 문서: [`docs/README-legacy-db-separation.md`](docs/README-legacy-db-separation.md)
+- 운영 DB 일원화 전환 절차: [`docs/db-consolidation-runbook.md`](docs/db-consolidation-runbook.md)
+
+### 주요 변경 사항
+
+| 구분 | 이전 | 현재 |
+|------|------|------|
+| 데이터베이스 | MySQL 8.0 + PostgreSQL/PostGIS 이중 구성 | PostgreSQL 15 + PostGIS 3.3 단일 구성 |
+| 스키마 관리 | JPA DDL + 별도 PostGIS init SQL | Flyway 마이그레이션 |
+| 로컬 실행 | DB 컨테이너 수동 기동 | `bootRun` 시 spring-boot-docker-compose 자동 기동 |
+| 테스트 | primary/secondary datasource 기반 H2 | 단일 H2(PostgreSQL mode) + Testcontainers PostGIS 검증 |
+
+<br/>
+
 ## ✨ 주요 기능
 
 ### 1. 모임 조율 플로우

--- a/docs/README-legacy-db-separation.md
+++ b/docs/README-legacy-db-separation.md
@@ -1,0 +1,88 @@
+# README 이전 버전: MySQL + PostGIS 분리 구성
+
+> 이 문서는 DB 일원화 이전 README의 인프라 기준을 별도로 보관하기 위한 기록입니다.
+> 현재 운영 기준은 루트 [`README.md`](../README.md)와 [`local-dev-setup.md`](local-dev-setup.md)를 확인합니다.
+
+## 보관 기준
+
+- 대상 시점: PostgreSQL+PostGIS 단일 DB 전환 이전
+- 도메인 데이터: MySQL 8.0
+- 공간 데이터: PostgreSQL 15 + PostGIS 3.3
+- 지하철역 공간 데이터 초기화: 별도 `postgis-init.sql` 배포/실행
+- Spring datasource 구성: `primary`/`secondary` 분리 설정
+
+## 당시 기술 스택 차이
+
+| 분류 | 이전 구성 | 현재 구성 |
+|------|-----------|-----------|
+| Domain DB | MySQL 8.0 | PostgreSQL 15 + PostGIS 3.3 |
+| Spatial DB | PostgreSQL 15 + PostGIS 3.3 | PostgreSQL 15 + PostGIS 3.3 |
+| Datasource | primary/secondary 이중 datasource | Spring Boot 자동 구성 단일 datasource |
+| Schema 관리 | JPA DDL + 별도 PostGIS init SQL | Flyway `V1`/`V2` 마이그레이션 |
+| Local 실행 | MySQL, PostgreSQL+PostGIS, Redis 직접 기동 | spring-boot-docker-compose가 PostgreSQL+PostGIS, Redis 자동 기동 |
+
+## 이전 시스템 아키텍처
+
+```mermaid
+flowchart TB
+    Client["Client"]
+
+    subgraph API["Spring Boot API Server (:8080)"]
+        direction TB
+        C1["Meeting Controller"]
+        C2["Participant Controller"]
+        C3["Schedule Controller"]
+        C4["Location Controller"]
+        SVC["Service Layer"]
+        C1 & C2 & C3 & C4 --> SVC
+    end
+
+    subgraph EXT["External APIs"]
+        Google["Google Routes"]
+        Odsay["ODsay"]
+        Kakao["Kakao Local / Directions"]
+        GooglePlaces["Google Places"]
+    end
+
+    subgraph DB["Persistence Layer"]
+        MySQL[("MySQL 8.0\n도메인 데이터")]
+        PostGIS[("PostgreSQL+PostGIS\n지하철역 공간 데이터")]
+    end
+
+    subgraph MON["Monitoring Stack"]
+        Prometheus["Prometheus"]
+        Loki["Loki"]
+        Grafana["Grafana"]
+    end
+
+    Client -->|HTTPS| API
+    SVC --> EXT
+    SVC --> MySQL
+    SVC --> PostGIS
+    API -->|Actuator| Prometheus
+    API -->|Logback| Loki
+    Prometheus & Loki --> Grafana
+```
+
+## 이전 로컬 실행 방식
+
+```bash
+# 1. 인프라 컨테이너 실행
+docker-compose up -d mysql postgres redis
+
+# 2. Spring Boot 실행 (local 프로파일)
+./gradlew bootRun --args='--spring.profiles.active=local'
+```
+
+## 이전 DB 접속 정보
+
+| DB | Host | Port | Database | User | Password |
+|----|------|------|----------|------|----------|
+| MySQL | localhost | 3306 | moyeolak | moyeolak | moyeolak |
+| PostgreSQL+PostGIS | localhost | 5432 | moyeolak_spatial | moyeolak | moyeolak |
+
+## 현재 문서로 이동
+
+- 현재 README: [`../README.md`](../README.md)
+- 로컬 개발 가이드: [`local-dev-setup.md`](local-dev-setup.md)
+- 운영 DB 일원화 전환 절차: [`db-consolidation-runbook.md`](db-consolidation-runbook.md)


### PR DESCRIPTION
## Issue Number
related #137

## As-Is
<!-- 문제 상황 정의 -->
- README가 PostgreSQL+PostGIS 단일 DB 전환 이후 내용을 기준으로 바뀌었지만, 이전 MySQL+PostGIS 분리 구성 문서를 바로 찾아갈 수 있는 별도 문서 링크가 필요했습니다.
- DB 일원화 전후 변경점이 README 안에서 명확히 구분되지 않아, 기존 구성과 현재 구성을 비교하기 어려웠습니다.

## To-Be
<!-- 변경 사항 -->
- README에 `문서 버전` 섹션을 추가해 현재 문서 기준과 이전 버전 문서 링크를 명시했습니다.
- `docs/README-legacy-db-separation.md`를 추가해 MySQL+PostGIS 분리 구성의 실행 방식, DB 접속 정보, 아키텍처를 별도 보관했습니다.
- README에서 운영 DB 일원화 전환 런북도 함께 연결했습니다.

## Review Request (중요)
- 코드 리뷰는 **한국어로 작성**해주세요.
- 구현 의도, 리스크, 개선 포인트 중심으로 리뷰 부탁드립니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
- 문서 변경만 포함된 PR입니다.
- 기존 DB 일원화 PR #138이 `dev`에 merge된 뒤, `origin/dev` 기준 새 PR 전용 브랜치로 정리했습니다.
- 검증: `git diff --check HEAD^..HEAD`
