### PR TITLE
chore(deploy): env 사전 체크 및 슬랙 배포 알림 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,6 +96,16 @@ jobs:
             set -e
             cd /app/moyeolak
 
+            if [ ! -f .env ]; then
+              echo "ERROR: /app/moyeolak/.env 파일이 없습니다. 서버에 .env를 생성해주세요."
+              exit 1
+            fi
+            if [ ! -r .env ]; then
+              echo "ERROR: /app/moyeolak/.env를 읽을 수 없습니다. (현재: $(ls -l .env))"
+              echo "서버에서 'sudo chown ubuntu:ubuntu /app/moyeolak/.env' 실행 후 재시도하세요."
+              exit 1
+            fi
+
             aws ecr get-login-password --region ap-northeast-2 \
               | docker login --username AWS --password-stdin ${{ steps.ecr-login.outputs.registry }}
 
@@ -113,3 +123,23 @@ jobs:
             --group-id ${{ secrets.AWS_SG_ID }} \
             --protocol tcp --port 22 \
             --cidr ${{ steps.runner-ip.outputs.ipv4 }}/32
+
+      # 커밋 메시지 본문(멀티라인)이 Slack 페이로드 YAML을 깨지 않도록 제목만 추출
+      - name: Prepare Slack message
+        if: always()
+        id: slack-prep
+        run: echo "commit_title=$(git log -1 --pretty=%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Notify Slack
+        if: always()
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "${{ job.status == 'success' && '✅ 배포 성공' || '❌ 배포 실패' }} — moyeolak-backend (${{ github.ref_name }})"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "${{ job.status == 'success' && ':white_check_mark: *배포 성공*' || ':x: *배포 실패*' }} — *moyeolak-backend*\n*브랜치:* `${{ github.ref_name }}`\n*커밋:* ${{ steps.slack-prep.outputs.commit_title }}\n*작성자:* ${{ github.actor }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|워크플로우 실행 보기>"


### PR DESCRIPTION
## 개요

배포 워크플로우(deploy.yml)에 두 가지 안전장치를 추가합니다.

## 변경 사항

### 1. `.env` 사전 체크 가드
- 오늘(7/17) 배포 실패 원인이었던 `open /app/moyeolak/.env: permission denied`를 조기에 진단합니다.
- docker 작업 전에 `.env` 존재 여부와 읽기 권한을 검사하고, 실패 시 현재 권한 상태와 해결 방법(`sudo chown ubuntu:ubuntu`)을 로그에 출력합니다.

### 2. 슬랙 배포 알림
- `slackapi/slack-github-action@v3.0.3` 사용, `if: always()`로 성공/실패 모두 알림
- 브랜치, 커밋 제목, 작성자, 워크플로우 실행 링크 포함
- squash 머지 커밋의 멀티라인 본문이 페이로드 YAML을 깨지 않도록 커밋 제목 첫 줄만 추출
- `SLACK_WEBHOOK_URL` 시크릿 등록 완료, 웹훅 테스트 발송 확인 완료

## 테스트

- [x] 웹훅 curl 테스트 메시지 정상 수신
- [ ] 머지 후 실제 배포에서 알림 수신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)