### PR TITLE
fix(location): 서비스 지역 밖 출발지 차단 및 경로 없음 에러 처리 개선

### DIFF
--- a/src/main/java/com/dnd/moyeolak/domain/location/dto/RouteDto.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/dto/RouteDto.java
@@ -20,9 +20,15 @@ public record RouteDto(
         @Schema(description = "대중교통 이동거리 (미터)", example = "21400")
         int transitDistance,
 
+        @Schema(description = "대중교통 도달 가능 여부 (false면 이동시간은 999 고정값)", example = "true")
+        boolean transitReachable,
+
         @Schema(description = "자가용 이동시간 (분)", example = "45")
         int drivingDuration,
 
         @Schema(description = "자가용 이동거리 (미터)", example = "18200")
-        int drivingDistance
+        int drivingDistance,
+
+        @Schema(description = "자가용 도달 가능 여부 (false면 이동시간은 999 고정값)", example = "true")
+        boolean drivingReachable
 ) {}

--- a/src/main/java/com/dnd/moyeolak/domain/location/service/impl/LocationVoteServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/service/impl/LocationVoteServiceImpl.java
@@ -31,6 +31,12 @@ public class LocationVoteServiceImpl implements LocationVoteService {
     private final ParticipantService participantService;
     private final LocationVoteRepository locationVoteRepository;
 
+    // 수도권 전철망 커버리지 기준 서비스 지역 (남: 신창 36.77, 북: 소요산 37.95, 서: 인천 126.45, 동: 춘천 127.73 + 여유분)
+    private static final double SERVICE_AREA_MIN_LAT = 36.5;
+    private static final double SERVICE_AREA_MAX_LAT = 38.2;
+    private static final double SERVICE_AREA_MIN_LNG = 126.2;
+    private static final double SERVICE_AREA_MAX_LNG = 128.0;
+
     @Override
     public List<LocationVoteResponse> listLocationVote(String meetingId) {
         Meeting meeting = meetingRepository.findByIdWithAllAssociations(meetingId)
@@ -51,6 +57,8 @@ public class LocationVoteServiceImpl implements LocationVoteService {
     @Transactional
     @CacheEvict(value = "midpointRecommendations", allEntries = true)
     public void updateLocationVote(Long locationVoteId, UpdateLocationVoteRequest request) {
+        validateServiceArea(request.departureLat(), request.departureLng());
+
         LocationVote locationVote = locationVoteRepository.findById(locationVoteId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.LOCATION_VOTE_NOT_FOUND));
         locationVote.update(request);
@@ -60,6 +68,8 @@ public class LocationVoteServiceImpl implements LocationVoteService {
     @Transactional
     @CacheEvict(value = "midpointRecommendations", allEntries = true)
     public Long createLocationVote(CreateLocationVoteRequest request) {
+        validateServiceArea(request.departureLat(), request.departureLng());
+
         Meeting meeting = meetingRepository.findByIdWithAllAssociations(request.meetingId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));
 
@@ -92,6 +102,22 @@ public class LocationVoteServiceImpl implements LocationVoteService {
         participantService.save(participant);
 
         return locationVote.getId();
+    }
+
+    private void validateServiceArea(String departureLat, String departureLng) {
+        double lat;
+        double lng;
+        try {
+            lat = Double.parseDouble(departureLat);
+            lng = Double.parseDouble(departureLng);
+        } catch (NumberFormatException e) {
+            throw new BusinessException(ErrorCode.INVALID_FORMAT);
+        }
+
+        if (lat < SERVICE_AREA_MIN_LAT || lat > SERVICE_AREA_MAX_LAT
+                || lng < SERVICE_AREA_MIN_LNG || lng > SERVICE_AREA_MAX_LNG) {
+            throw new BusinessException(ErrorCode.OUT_OF_SERVICE_AREA);
+        }
     }
 
     @Override

--- a/src/main/java/com/dnd/moyeolak/domain/location/service/impl/MidpointRecommendationServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/service/impl/MidpointRecommendationServiceImpl.java
@@ -177,12 +177,13 @@ public class MidpointRecommendationServiceImpl implements MidpointRecommendation
         }
 
         if (evaluations.isEmpty()) {
-            throw new BusinessException(ErrorCode.GOOGLE_API_ERROR);
+            throw new BusinessException(ErrorCode.NO_REACHABLE_STATIONS);
         }
 
+        // 도달 불가 참가자가 적은 역이 우선 — 일부만 갈 수 있는 역이 짧은 평균만으로 1위가 되지 않도록
         return evaluations.stream()
-                .sorted(Comparator.comparingDouble(StationEvaluation::avgTransitDuration)
-                        .thenComparingInt(StationEvaluation::unreachableTransitRouteCount)
+                .sorted(Comparator.comparingInt(StationEvaluation::unreachableTransitRouteCount)
+                        .thenComparingDouble(StationEvaluation::avgTransitDuration)
                         .thenComparingInt(StationEvaluation::distanceFromCenter))
                 .limit(TOP_RECOMMENDATIONS)
                 .toList();
@@ -213,8 +214,10 @@ public class MidpointRecommendationServiceImpl implements MidpointRecommendation
                                 .departureAddress(vote.getDepartureLocation())
                                 .transitDuration(transitRoute.durationMinutes())
                                 .transitDistance(transitRoute.distanceMeters())
+                                .transitReachable(transitRoute.reachable())
                                 .drivingDuration(drivingRoute.durationSeconds() / 60)
                                 .drivingDistance(drivingRoute.distanceMeters())
+                                .drivingReachable(drivingRoute.reachable())
                                 .build());
                     }
 

--- a/src/main/java/com/dnd/moyeolak/domain/location/service/impl/PersonalRouteQueryServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/service/impl/PersonalRouteQueryServiceImpl.java
@@ -91,8 +91,12 @@ public class PersonalRouteQueryServiceImpl implements PersonalRouteQueryService 
                 station.getLongitude()
         );
 
-        if (pathInfo == null || pathInfo.safeTotal() >= 999) {
+        if (pathInfo == null) {
             throw new BusinessException(ErrorCode.ODSAY_API_ERROR);
+        }
+        // ODsay가 경로를 찾지 못하면 999분 응답 — API 장애가 아니라 경로 부재
+        if (pathInfo.safeTotal() >= 999) {
+            throw new BusinessException(ErrorCode.ROUTE_NOT_FOUND);
         }
 
         int transferCount = pathInfo.safeBusTransit() + pathInfo.safeSubwayTransit();
@@ -120,7 +124,7 @@ public class PersonalRouteQueryServiceImpl implements PersonalRouteQueryService 
         );
 
         if (summary == null) {
-            throw new BusinessException(ErrorCode.KAKAO_API_ERROR);
+            throw new BusinessException(ErrorCode.ROUTE_NOT_FOUND);
         }
 
         int durationMinutes = summary.duration() / 60;

--- a/src/main/java/com/dnd/moyeolak/global/response/ErrorCode.java
+++ b/src/main/java/com/dnd/moyeolak/global/response/ErrorCode.java
@@ -35,6 +35,9 @@ public enum ErrorCode {
     KAKAO_API_ERROR("E424", "자동차 경로 조회에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     INSUFFICIENT_LOCATION_VOTES("E425", "출발지 2개 이상 등록 시 중간지점을 확인할 수 있습니다.", HttpStatus.BAD_REQUEST),
     INVALID_TIME_RANGE("E426", "시작 시간은 종료 시간보다 빨라야 합니다.", HttpStatus.BAD_REQUEST),
+    OUT_OF_SERVICE_AREA("E427", "서비스 지역(수도권) 밖의 출발지는 등록할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    ROUTE_NOT_FOUND("E428", "출발지에서 도착역까지 이동 경로를 찾을 수 없습니다.", HttpStatus.UNPROCESSABLE_ENTITY),
+    NO_REACHABLE_STATIONS("E429", "출발지에서 대중교통으로 도달 가능한 후보 역이 없습니다.", HttpStatus.UNPROCESSABLE_ENTITY),
 
     // 서버 오류
     SERVER_ERROR("E500", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/test/java/com/dnd/moyeolak/domain/location/service/LocationVoteUnitTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/location/service/LocationVoteUnitTest.java
@@ -218,6 +218,81 @@ class LocationVoteUnitTest {
     }
 
     @Nested
+    @DisplayName("서비스 지역 검증")
+    class ServiceAreaValidation {
+
+        @Test
+        @DisplayName("서비스 지역(수도권) 밖 좌표(독도)로 등록 시 OUT_OF_SERVICE_AREA 예외가 발생한다")
+        void createLocationVote_outOfServiceArea_throwsException() {
+            CreateLocationVoteRequest request = new CreateLocationVoteRequest(
+                    "meeting-id-123",
+                    null,
+                    "홍길동",
+                    "경북 울릉군 독도",
+                    "37.2426",
+                    "131.8597"
+            );
+
+            assertThatThrownBy(() -> locationService.createLocationVote(request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.OUT_OF_SERVICE_AREA);
+
+            verify(locationVoteRepository, never()).save(any());
+            verify(participantService, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("서비스 지역 남쪽 밖 좌표(제주)로 등록 시 OUT_OF_SERVICE_AREA 예외가 발생한다")
+        void createLocationVote_southOfServiceArea_throwsException() {
+            CreateLocationVoteRequest request = new CreateLocationVoteRequest(
+                    "meeting-id-123",
+                    null,
+                    "홍길동",
+                    "제주특별자치도 제주시",
+                    "33.4996",
+                    "126.5312"
+            );
+
+            assertThatThrownBy(() -> locationService.createLocationVote(request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.OUT_OF_SERVICE_AREA);
+        }
+
+        @Test
+        @DisplayName("숫자가 아닌 좌표로 등록 시 INVALID_FORMAT 예외가 발생한다")
+        void createLocationVote_nonNumericCoordinates_throwsException() {
+            CreateLocationVoteRequest request = new CreateLocationVoteRequest(
+                    "meeting-id-123",
+                    null,
+                    "홍길동",
+                    "서울시 강남구",
+                    "abc",
+                    "127.0276368"
+            );
+
+            assertThatThrownBy(() -> locationService.createLocationVote(request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_FORMAT);
+        }
+
+        @Test
+        @DisplayName("출발지 수정 시에도 서비스 지역 밖 좌표면 OUT_OF_SERVICE_AREA 예외가 발생한다")
+        void updateLocationVote_outOfServiceArea_throwsException() {
+            com.dnd.moyeolak.domain.meeting.dto.UpdateLocationVoteRequest request =
+                    new com.dnd.moyeolak.domain.meeting.dto.UpdateLocationVoteRequest(
+                            "홍길동",
+                            "경북 울릉군 독도",
+                            "37.2426",
+                            "131.8597"
+                    );
+
+            assertThatThrownBy(() -> locationService.updateLocationVote(1L, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.OUT_OF_SERVICE_AREA);
+        }
+    }
+
+    @Nested
     @DisplayName("중복 localStorageKey 예외")
     class DuplicateLocalStorageKey {
 

--- a/src/test/java/com/dnd/moyeolak/domain/location/service/MidpointRecommendationServiceImplTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/location/service/MidpointRecommendationServiceImplTest.java
@@ -37,6 +37,7 @@ import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -120,7 +121,7 @@ class MidpointRecommendationServiceImplTest {
         }
 
         @Test
-        @DisplayName("모든 후보역이 전원 도달 불가이면 GOOGLE_API_ERROR 예외가 발생한다")
+        @DisplayName("모든 후보역이 전원 도달 불가이면 NO_REACHABLE_STATIONS 예외가 발생한다")
         void throwsWhenAllTransitRoutesUnreachable() {
             mockMeetingWithLocationPoll();
             LocationVote vote1 = createMockVote("37.5000", "127.0000", "참가자A", "서울시 강남구");
@@ -138,7 +139,7 @@ class MidpointRecommendationServiceImplTest {
 
             assertThatThrownBy(() -> midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null))
                     .isInstanceOf(BusinessException.class)
-                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GOOGLE_API_ERROR);
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NO_REACHABLE_STATIONS);
         }
     }
 
@@ -255,6 +256,65 @@ class MidpointRecommendationServiceImplTest {
             assertThat(response.recommendations()).hasSize(1);
             assertThat(response.recommendations().getFirst().routes())
                     .extracting("drivingDuration").containsExactly(999, 999);
+        }
+
+        @Test
+        @DisplayName("도달 불가 참가자가 있는 역보다 전원 도달 가능한 역이 우선 추천된다")
+        void prefersFullyReachableStationOverPartiallyReachableOne() {
+            mockMeetingWithLocationPoll();
+            LocationVote vote1 = createMockVote("37.5000", "127.0000", "참가자A", "서울시 강남구");
+            LocationVote vote2 = createMockVote("37.5100", "127.0100", "참가자B", "서울시 강동구");
+            when(locationVoteRepository.findByLocationPoll_Id(1L)).thenReturn(List.of(vote1, vote2));
+            when(stationRepository.calculateCentroid(any())).thenThrow(new RuntimeException("PostGIS 미지원"));
+            Station partiallyReachable = createMockStation(1L, "역1", "1호선", 37.50, 127.01);
+            Station fullyReachable = createMockStation(2L, "역2", "2호선", 37.51, 127.02);
+            when(stationRepository.findNearbyStations(anyDouble(), anyDouble(), anyInt(), anyInt()))
+                    .thenReturn(List.of(partiallyReachable, fullyReachable));
+            // 역1: 참가자A만 도달 가능(10분, 평균 10분) / 역2: 전원 도달 가능(평균 50분)
+            when(googleRoutesClient.computeTransitMatrix(anyList(), anyList(), any()))
+                    .thenReturn(List.of(
+                            List.of(new TransitRouteResult(10, 1000, true), new TransitRouteResult(50, 5000, true)),
+                            List.of(TransitRouteResult.unreachable(), new TransitRouteResult(50, 5000, true))
+                    ));
+            when(kakaoDirectionsClient.requestDrivingRoute(anyDouble(), anyDouble(), anyDouble(), anyDouble(), any()))
+                    .thenReturn(new KakaoDirectionsResponse.Summary(5000, 600, null));
+
+            MidpointRecommendationResponse response =
+                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null);
+
+            assertThat(response.recommendations()).extracting("stationName")
+                    .containsExactly("역2", "역1");
+        }
+
+        @Test
+        @DisplayName("도달 불가 경로는 RouteDto의 reachable 플래그가 false로 내려간다")
+        void marksUnreachableRoutesInRouteDto() {
+            mockMeetingWithLocationPoll();
+            LocationVote vote1 = createMockVote("37.5000", "127.0000", "참가자A", "서울시 강남구");
+            LocationVote vote2 = createMockVote("37.2426", "131.8597", "참가자B", "경북 울릉군 독도");
+            when(locationVoteRepository.findByLocationPoll_Id(1L)).thenReturn(List.of(vote1, vote2));
+            when(stationRepository.calculateCentroid(any())).thenThrow(new RuntimeException("PostGIS 미지원"));
+            Station station = createMockStation(6L, "역삼역", "2호선", 37.5006, 127.0366);
+            when(stationRepository.findNearbyStations(anyDouble(), anyDouble(), anyInt(), anyInt()))
+                    .thenReturn(List.of(station));
+            when(googleRoutesClient.computeTransitMatrix(anyList(), anyList(), any()))
+                    .thenReturn(List.of(
+                            List.of(new TransitRouteResult(10, 5000, true)),
+                            List.of(TransitRouteResult.unreachable())
+                    ));
+            // 참가자A는 자동차 경로 성공, 참가자B(독도)는 실패(null)
+            when(kakaoDirectionsClient.requestDrivingRoute(eq(37.5000), anyDouble(), anyDouble(), anyDouble(), any()))
+                    .thenReturn(new KakaoDirectionsResponse.Summary(5000, 600, null));
+            when(kakaoDirectionsClient.requestDrivingRoute(eq(37.2426), anyDouble(), anyDouble(), anyDouble(), any()))
+                    .thenReturn(null);
+
+            MidpointRecommendationResponse response =
+                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null);
+
+            assertThat(response.recommendations().getFirst().routes())
+                    .extracting("transitReachable").containsExactly(true, false);
+            assertThat(response.recommendations().getFirst().routes())
+                    .extracting("drivingReachable").containsExactly(true, false);
         }
 
         @Test

--- a/src/test/java/com/dnd/moyeolak/domain/location/service/PersonalRouteQueryServiceImplTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/location/service/PersonalRouteQueryServiceImplTest.java
@@ -110,11 +110,25 @@ class PersonalRouteQueryServiceImplTest {
     }
 
     @Test
-    @DisplayName("대중교통 조회가 실패하면 ODSAY_API_ERROR를 발생시킨다")
-    void throwsWhenTransitFails() {
+    @DisplayName("대중교통 경로가 없으면(999) ROUTE_NOT_FOUND를 발생시킨다")
+    void throwsRouteNotFoundWhenTransitRouteMissing() {
         setupCommonMocks();
         when(odsayClient.searchRoute(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
                 .thenReturn(new OdsayPathInfo(999, 0, 0, 0, 0, 0, 0));
+
+        assertThatThrownBy(() -> personalRouteQueryService.getPersonalRoute(
+                MEETING_ID, STATION_ID, PARTICIPANT_ID, null, RouteMode.TRANSIT
+        ))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROUTE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("ODsay API 호출 자체가 실패하면(null) ODSAY_API_ERROR를 발생시킨다")
+    void throwsOdsayApiErrorWhenClientFails() {
+        setupCommonMocks();
+        when(odsayClient.searchRoute(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(null);
 
         assertThatThrownBy(() -> personalRouteQueryService.getPersonalRoute(
                 MEETING_ID, STATION_ID, PARTICIPANT_ID, null, RouteMode.TRANSIT
@@ -124,8 +138,8 @@ class PersonalRouteQueryServiceImplTest {
     }
 
     @Test
-    @DisplayName("자동차 조회가 실패하면 KAKAO_API_ERROR를 발생시킨다")
-    void throwsWhenDrivingFails() {
+    @DisplayName("자동차 경로가 없으면 ROUTE_NOT_FOUND를 발생시킨다")
+    void throwsRouteNotFoundWhenDrivingRouteMissing() {
         setupCommonMocks();
         when(odsayClient.searchRoute(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
                 .thenReturn(new OdsayPathInfo(30, 1000, 0, 0, 5000, 100, 0));
@@ -136,7 +150,7 @@ class PersonalRouteQueryServiceImplTest {
                 MEETING_ID, STATION_ID, PARTICIPANT_ID, null, RouteMode.DRIVING
         ))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.KAKAO_API_ERROR);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROUTE_NOT_FOUND);
     }
 
     @Test


### PR DESCRIPTION
## Issue Number
closed #139

## As-Is
- 출발지 좌표 검증이 없어 독도 등 서비스 지역 밖 좌표도 등록 가능
- 참가자 2명(서울+독도)이면 무게중심이 동해 바다로 계산되어 `NO_NEARBY_STATIONS`(404), 프론트에선 서버 에러로 노출
- 개인별 경로에서 "경로 없음"(정상 비즈니스 상황)을 `ODSAY_API_ERROR`/`KAKAO_API_ERROR`(500)로 응답
- 전 후보역 도달 불가 시에도 `GOOGLE_API_ERROR`(500)로 뭉뚱그려짐
- 도달 불가 참가자의 999분이 실제 소요시간처럼 응답에 내려감

## To-Be
- **좌표 검증**: 출발지 등록/수정 시 수도권 전철망 기준 bounding box(위도 36.5~38.2, 경도 126.2~128.0) 검증 → `OUT_OF_SERVICE_AREA`(E427, 400). 숫자가 아닌 좌표는 `INVALID_FORMAT`
- **경로 없음 분리**: ODsay 999 응답·Kakao 빈 응답 → `ROUTE_NOT_FOUND`(E428, 422). ODsay 호출 자체 실패(null)만 기존 500 유지
- **전 역 도달 불가**: `NO_REACHABLE_STATIONS`(E429, 422)로 분리
- **RouteDto**: `transitReachable`/`drivingReachable` 플래그 추가
- **정렬 개선**: 도달 불가 인원 수 우선 정렬 — 일부만 갈 수 있는 역이 짧은 평균만으로 1위가 되지 않도록

## Review Request (중요)
- 코드 리뷰는 **한국어로 작성**해주세요.
- 서비스 지역 bounding box 범위(수도권 전철망 + 여유분)가 적절한지, E428/E429의 422 상태코드 선택이 프론트 처리 관점에서 괜찮은지 중점적으로 봐주세요.

## Check List
- [x] 테스트가 전부 통과되었나요? (location 도메인 단위 테스트 + 신규 테스트 9개, `./gradlew test` 전체 통과)
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요? (dev)
- [ ] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
- 프론트엔드 대응 PR: dnd-side-project/dnd-14th-8-frontend#126 (E417/E427/E428 처리 및 검색 단계 차단)

🤖 Generated with [Claude Code](https://claude.com/claude-code)