### PR TITLE
docs: 서비스 주소 및 인프라 배지 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,16 @@
 
 로그인 없이 모임을 만들고, 일정과 출발지를 투표로 정하고, **중간 지점 역**을 자동으로 추천받는 모임 조율 서비스
 
+**서비스 주소**: [https://moyeorak.site/](https://moyeorak.site/)
+
 <br/>
 
 ![Java](https://img.shields.io/badge/Java_25-007396?style=flat-square&logo=openjdk&logoColor=white)
 ![Spring Boot](https://img.shields.io/badge/Spring_Boot_4.0-6DB33F?style=flat-square&logo=springboot&logoColor=white)
 ![PostgreSQL](https://img.shields.io/badge/PostGIS_15-336791?style=flat-square&logo=postgresql&logoColor=white)
 ![Docker](https://img.shields.io/badge/Docker-2496ED?style=flat-square&logo=docker&logoColor=white)
+![Terraform](https://img.shields.io/badge/Terraform-844FBA?style=flat-square&logo=terraform&logoColor=white)
+![AWS](https://img.shields.io/badge/AWS-232F3E?style=flat-square&logo=amazonwebservices&logoColor=white)
 ![Prometheus](https://img.shields.io/badge/Prometheus-E6522C?style=flat-square&logo=prometheus&logoColor=white)
 ![Grafana](https://img.shields.io/badge/Grafana-F46800?style=flat-square&logo=grafana&logoColor=white)
 


### PR DESCRIPTION
## 변경 사항
- README 상단에 운영 서비스 주소를 추가했습니다.
- 실제 infra/terraform 기반 운영 인프라 구성을 반영해 Terraform, AWS 기술 배지를 추가했습니다.

## 영향
- 프로젝트 README에서 서비스 접근 URL과 인프라 기술 스택을 더 명확히 확인할 수 있습니다.
- 애플리케이션 코드 변경은 없습니다.

## 검증
- git diff --check