### PR TITLE
fix(location): 출발지 추가 분기 개선 — participantId 대리 등록 및 기존 참여자 본인 등록 허용

### DIFF
--- a/src/main/java/com/dnd/moyeolak/domain/location/docs/CreateLocationVoteApiDocs.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/docs/CreateLocationVoteApiDocs.java
@@ -64,18 +64,59 @@ import java.lang.annotation.Target;
         ),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "404",
-                description = "모임을 찾을 수 없음",
+                description = "모임 또는 참여자를 찾을 수 없음",
                 content = @Content(
                         mediaType = "application/json",
-                        examples = @ExampleObject(
-                                name = "모임 없음",
-                                value = """
-                                            {
-                                              "code": "E410",
-                                              "message": "모임이 존재하지 않습니다."
-                                            }
-                                            """
-                        )
+                        examples = {
+                                @ExampleObject(
+                                        name = "모임 없음",
+                                        value = """
+                                                    {
+                                                      "code": "E410",
+                                                      "message": "모임이 존재하지 않습니다."
+                                                    }
+                                                    """
+                                ),
+                                @ExampleObject(
+                                        name = "참여자 없음",
+                                        summary = "participantId에 해당하는 참여자가 모임에 없음",
+                                        value = """
+                                                    {
+                                                      "code": "E414",
+                                                      "message": "참여자가 존재하지 않습니다."
+                                                    }
+                                                    """
+                                )
+                        }
+                )
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "409",
+                description = "이미 출발지를 등록한 참여자",
+                content = @Content(
+                        mediaType = "application/json",
+                        examples = {
+                                @ExampleObject(
+                                        name = "localStorageKey 중복",
+                                        summary = "같은 브라우저 키로 이미 출발지를 등록함",
+                                        value = """
+                                                    {
+                                                      "code": "E413",
+                                                      "message": "이미 참여한 사용자입니다."
+                                                    }
+                                                    """
+                                ),
+                                @ExampleObject(
+                                        name = "participantId 중복",
+                                        summary = "지정한 참여자가 이미 출발지를 등록함",
+                                        value = """
+                                                    {
+                                                      "code": "E430",
+                                                      "message": "이미 출발지를 등록한 참여자입니다."
+                                                    }
+                                                    """
+                                )
+                        }
                 )
         )
 })

--- a/src/main/java/com/dnd/moyeolak/domain/location/dto/CreateLocationVoteRequest.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/dto/CreateLocationVoteRequest.java
@@ -11,6 +11,9 @@ public record CreateLocationVoteRequest(
     @Schema(description = "브라우저 로컬스토리지 키 (재참여 방지용)", example = "ls_key_abc123")
     String localStorageKey,
 
+    @Schema(description = "출발지를 연결할 기존 참여자 ID (대리 추가 시 지정)", example = "1")
+    Long participantId,
+
     @Schema(description = "참여자 이름", example = "김철수")
     @NotBlank String participantName,
 

--- a/src/main/java/com/dnd/moyeolak/domain/location/service/impl/LocationVoteServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/service/impl/LocationVoteServiceImpl.java
@@ -76,6 +76,20 @@ public class LocationVoteServiceImpl implements LocationVoteService {
         LocationPoll locationPoll = meeting.getLocationPoll();
         LocationVote locationVote = LocationVote.fromByCreateLocationVoteRequest(locationPoll, request);
 
+        if (request.participantId() != null) {
+            Participant participant = meeting.getParticipants().stream()
+                    .filter(p -> request.participantId().equals(p.getId()))
+                    .findFirst()
+                    .orElseThrow(() -> new BusinessException(ErrorCode.PARTICIPANT_NOT_FOUND));
+
+            if (!participant.getLocationVotes().isEmpty()) {
+                throw new BusinessException(ErrorCode.DUPLICATE_LOCATION_VOTE);
+            }
+            participant.addLocationVote(locationVote);
+            locationVoteRepository.save(locationVote);
+            return locationVote.getId();
+        }
+
         if (!StringUtils.hasText(request.localStorageKey())) {
             locationVoteRepository.save(locationVote);
             return locationVote.getId();
@@ -86,12 +100,11 @@ public class LocationVoteServiceImpl implements LocationVoteService {
                 .findFirst();
 
         if (existingParticipant.isPresent()) {
-            Participant host = existingParticipant.get();
-            if (!host.isHost() || !host.getLocationVotes().isEmpty()) {
+            Participant participant = existingParticipant.get();
+            if (!participant.getLocationVotes().isEmpty()) {
                 throw new BusinessException(ErrorCode.DUPLICATE_LOCAL_STORAGE_KEY);
             }
-            host.updateName(request.participantName());
-            host.addLocationVote(locationVote);
+            participant.addLocationVote(locationVote);
             locationVoteRepository.save(locationVote);
             return locationVote.getId();
         }

--- a/src/main/java/com/dnd/moyeolak/global/response/ErrorCode.java
+++ b/src/main/java/com/dnd/moyeolak/global/response/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     OUT_OF_SERVICE_AREA("E427", "서비스 지역(수도권) 밖의 출발지는 등록할 수 없습니다.", HttpStatus.BAD_REQUEST),
     ROUTE_NOT_FOUND("E428", "출발지에서 도착역까지 이동 경로를 찾을 수 없습니다.", HttpStatus.UNPROCESSABLE_ENTITY),
     NO_REACHABLE_STATIONS("E429", "출발지에서 대중교통으로 도달 가능한 후보 역이 없습니다.", HttpStatus.UNPROCESSABLE_ENTITY),
+    DUPLICATE_LOCATION_VOTE("E430", "이미 출발지를 등록한 참여자입니다.", HttpStatus.CONFLICT),
 
     // 서버 오류
     SERVER_ERROR("E500", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/test/java/com/dnd/moyeolak/domain/location/service/LocationVoteIntegrationTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/location/service/LocationVoteIntegrationTest.java
@@ -49,6 +49,7 @@ class LocationVoteIntegrationTest {
         CreateLocationVoteRequest request = new CreateLocationVoteRequest(
                 meetingId,
                 null,
+                null,
                 "홍길동",
                 "서울시 강남구",
                 "37.4979502",
@@ -78,6 +79,7 @@ class LocationVoteIntegrationTest {
         CreateLocationVoteRequest request = new CreateLocationVoteRequest(
                 meetingId,
                 "new-local-key",
+                null,
                 "김철수",
                 "서울시 홍대입구",
                 "37.5571010",
@@ -106,6 +108,7 @@ class LocationVoteIntegrationTest {
 
         CreateLocationVoteRequest request = new CreateLocationVoteRequest(
                 meetingId,
+                null,
                 null,
                 "홍길동",
                 "서울시 강남구",
@@ -143,6 +146,7 @@ class LocationVoteIntegrationTest {
         CreateLocationVoteRequest request = new CreateLocationVoteRequest(
                 meetingId,
                 "local-storage-key-new",
+                null,
                 "김철수",
                 "서울시 홍대입구",
                 "37.5571010",
@@ -184,6 +188,7 @@ class LocationVoteIntegrationTest {
         CreateLocationVoteRequest request = new CreateLocationVoteRequest(
                 meetingId,
                 "local-storage-key-cascade",
+                null,
                 "이영희",
                 "서울시 왕십리",
                 "37.5614080",
@@ -218,6 +223,7 @@ class LocationVoteIntegrationTest {
         CreateLocationVoteRequest manualRequest = new CreateLocationVoteRequest(
                 meetingId,
                 null,
+                null,
                 "수동입력자",
                 "서울시 서초구",
                 "37.4837121",
@@ -227,6 +233,7 @@ class LocationVoteIntegrationTest {
         CreateLocationVoteRequest participantRequest = new CreateLocationVoteRequest(
                 meetingId,
                 "local-storage-key-mix",
+                null,
                 "박민수",
                 "서울시 부평",
                 "37.5074100",
@@ -249,6 +256,82 @@ class LocationVoteIntegrationTest {
     }
 
     @Test
+    @DisplayName("participantId 지정 추가 시 해당 참여자에 LocationVote가 연결되어 DB에 저장된다")
+    void createLocationVote_withParticipantId_persistsVoteLinkedToParticipant() {
+        // given - 모임 생성 후 출발지 없는 일반 참여자 추가
+        String meetingId = createTestMeeting();
+        Meeting meeting = meetingRepository.findByIdWithAllAssociations(meetingId).orElseThrow();
+        Participant friend = Participant.of(meeting, "friend-key", "친구");
+        em.persist(friend);
+        em.flush();
+        em.clear();
+        Long friendId = friend.getId();
+
+        CreateLocationVoteRequest request = new CreateLocationVoteRequest(
+                meetingId,
+                "host-key-proxy",
+                friendId,
+                "친구",
+                "서울시 송파구",
+                "37.5145430",
+                "127.1058860"
+        );
+
+        // when
+        Long locationVoteId = locationVoteService.createLocationVote(request);
+        em.flush();
+        em.clear();
+
+        // then
+        LocationVote saved = em.find(LocationVote.class, locationVoteId);
+        assertThat(saved).isNotNull();
+        assertThat(saved.getParticipant()).isNotNull();
+        assertThat(saved.getParticipant().getId()).isEqualTo(friendId);
+        assertThat(saved.getDepartureLocation()).isEqualTo("서울시 송파구");
+    }
+
+    @Test
+    @DisplayName("출발지 없는 기존 일반 참여자가 자신의 localStorageKey로 등록 시 기존 Participant에 연결된다")
+    void createLocationVote_existingNonHostByKey_persistsVoteLinkedToParticipant() {
+        // given - 모임 생성 후 출발지 없는 일반 참여자 추가 (일정 투표만 한 상태)
+        String meetingId = createTestMeeting();
+        Meeting meeting = meetingRepository.findByIdWithAllAssociations(meetingId).orElseThrow();
+        Participant member = Participant.of(meeting, "member-key", "일반참여자");
+        em.persist(member);
+        em.flush();
+        em.clear();
+        Long memberId = member.getId();
+
+        CreateLocationVoteRequest request = new CreateLocationVoteRequest(
+                meetingId,
+                "member-key",
+                null,
+                "일반참여자",
+                "서울시 성동구",
+                "37.5633450",
+                "127.0371250"
+        );
+
+        // when
+        Long locationVoteId = locationVoteService.createLocationVote(request);
+        em.flush();
+        em.clear();
+
+        // then - 새 Participant가 생기지 않고 기존 참여자에 연결
+        LocationVote saved = em.find(LocationVote.class, locationVoteId);
+        assertThat(saved.getParticipant()).isNotNull();
+        assertThat(saved.getParticipant().getId()).isEqualTo(memberId);
+
+        List<Participant> participants = em.createQuery(
+                "SELECT p FROM Participant p WHERE p.meeting.id = :meetingId AND p.localStorageKey = :key",
+                Participant.class)
+                .setParameter("meetingId", meetingId)
+                .setParameter("key", "member-key")
+                .getResultList();
+        assertThat(participants).hasSize(1);
+    }
+
+    @Test
     @DisplayName("출발지 삭제 시 LocationVote가 DB에서 삭제된다")
     void deleteLocationVote_removesLocationVoteFromDb() {
         // given - 모임 생성 후 참여자와 LocationVote 추가
@@ -259,6 +342,7 @@ class LocationVoteIntegrationTest {
         CreateLocationVoteRequest request = new CreateLocationVoteRequest(
                 meetingId,
                 "local-storage-key-delete",
+                null,
                 "홍길동",
                 "서울시 강남구",
                 "37.4979502",
@@ -298,6 +382,7 @@ class LocationVoteIntegrationTest {
         CreateLocationVoteRequest createRequest = new CreateLocationVoteRequest(
                 meetingId,
                 "local-storage-key-update",
+                null,
                 "홍길동",
                 "서울시 강남구",
                 "37.4979502",

--- a/src/test/java/com/dnd/moyeolak/domain/location/service/LocationVoteUnitTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/location/service/LocationVoteUnitTest.java
@@ -20,6 +20,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -59,6 +60,7 @@ class LocationVoteUnitTest {
             CreateLocationVoteRequest request = new CreateLocationVoteRequest(
                     meetingId,
                     null,  // localStorageKey가 null → 수동 추가
+                    null,
                     "홍길동",
                     "서울시 강남구",
                     "37.4979502",
@@ -91,6 +93,7 @@ class LocationVoteUnitTest {
             CreateLocationVoteRequest request = new CreateLocationVoteRequest(
                     meetingId,
                     "",  // 빈 문자열 → 수동 추가
+                    null,
                     "김철수",
                     "서울시 홍대입구",
                     "37.5571010",
@@ -121,6 +124,7 @@ class LocationVoteUnitTest {
             CreateLocationVoteRequest request = new CreateLocationVoteRequest(
                     meetingId,
                     "local-storage-key-abc",  // localStorageKey 존재, 신규 참여자
+                    null,
                     "이영희",
                     "서울시 왕십리",
                     "37.5614080",
@@ -159,6 +163,7 @@ class LocationVoteUnitTest {
             CreateLocationVoteRequest request = new CreateLocationVoteRequest(
                     meetingId,
                     "local-storage-key-xyz",
+                    null,
                     "박민수",
                     "서울시 서초구",
                     "37.4837121",
@@ -196,6 +201,7 @@ class LocationVoteUnitTest {
             CreateLocationVoteRequest request = new CreateLocationVoteRequest(
                     meetingId,
                     "host-key",
+                    null,
                     "모임장",
                     "서울시 마포구",
                     "37.5549340",
@@ -215,6 +221,171 @@ class LocationVoteUnitTest {
             assertThat(host.getLocationVotes()).hasSize(1);
             assertThat(host.getLocationVotes().get(0).getDepartureLocation()).isEqualTo("서울시 마포구");
         }
+
+        @Test
+        @DisplayName("모임장 첫 출발지 등록 시 요청 이름이 달라도 모임장 이름이 덮어써지지 않는다")
+        void createLocationVote_hostFirstVote_doesNotOverwriteHostName() {
+            // given
+            String meetingId = "meeting-id-789";
+            Meeting meeting = Meeting.ofId(meetingId);
+            Participant host = Participant.hostOf(meeting, "host-key", "모임장");
+            meeting.addParticipant(host);
+
+            CreateLocationVoteRequest request = new CreateLocationVoteRequest(
+                    meetingId,
+                    "host-key",
+                    null,
+                    "다른사람이름",
+                    "서울시 마포구",
+                    "37.5549340",
+                    "126.9137540"
+            );
+
+            when(meetingRepository.findByIdWithAllAssociations(meetingId)).thenReturn(Optional.of(meeting));
+
+            // when
+            locationService.createLocationVote(request);
+
+            // then
+            assertThat(host.getName()).isEqualTo("모임장");
+        }
+    }
+
+    @Nested
+    @DisplayName("기존 일반 참여자 본인 출발지 등록")
+    class ExistingParticipantFirstLocationVote {
+
+        @Test
+        @DisplayName("일정 투표로 참여한 일반 참여자가 첫 출발지 등록 시 기존 Participant에 연결된다")
+        void createLocationVote_existingNonHostFirstVote_savesVoteLinkedToExistingParticipant() {
+            // given
+            String meetingId = "meeting-id-321";
+            Meeting meeting = Meeting.ofId(meetingId);
+            Participant participant = Participant.of(meeting, "member-key", "일반참여자");
+            meeting.addParticipant(participant);
+            // 일정 투표로 이미 참여했지만 출발지는 아직 등록하지 않은 상태
+
+            CreateLocationVoteRequest request = new CreateLocationVoteRequest(
+                    meetingId,
+                    "member-key",
+                    null,
+                    "일반참여자",
+                    "서울시 성동구",
+                    "37.5633450",
+                    "127.0371250"
+            );
+
+            when(meetingRepository.findByIdWithAllAssociations(meetingId)).thenReturn(Optional.of(meeting));
+
+            // when
+            locationService.createLocationVote(request);
+
+            // then
+            verify(participantService, never()).save(any());
+            verify(locationVoteRepository).save(argThat(locationVote ->
+                    locationVote.getDepartureLocation().equals("서울시 성동구")
+            ));
+            assertThat(participant.getLocationVotes()).hasSize(1);
+            assertThat(participant.getLocationVotes().get(0).getDepartureLocation()).isEqualTo("서울시 성동구");
+        }
+    }
+
+    @Nested
+    @DisplayName("participantId 지정 추가 (대리 등록)")
+    class ParticipantIdAdd {
+
+        @Test
+        @DisplayName("participantId 지정 시 해당 참여자에 LocationVote가 연결된다")
+        void createLocationVote_withParticipantId_savesVoteLinkedToParticipant() {
+            // given
+            String meetingId = "meeting-id-555";
+            Meeting meeting = Meeting.ofId(meetingId);
+            Participant participant = Participant.of(meeting, "friend-key", "친구");
+            ReflectionTestUtils.setField(participant, "id", 10L);
+            meeting.addParticipant(participant);
+
+            CreateLocationVoteRequest request = new CreateLocationVoteRequest(
+                    meetingId,
+                    "host-key",
+                    10L,
+                    "친구",
+                    "서울시 송파구",
+                    "37.5145430",
+                    "127.1058860"
+            );
+
+            when(meetingRepository.findByIdWithAllAssociations(meetingId)).thenReturn(Optional.of(meeting));
+
+            // when
+            locationService.createLocationVote(request);
+
+            // then
+            verify(participantService, never()).save(any());
+            verify(locationVoteRepository).save(argThat(locationVote ->
+                    locationVote.getDepartureLocation().equals("서울시 송파구")
+            ));
+            assertThat(participant.getLocationVotes()).hasSize(1);
+            assertThat(participant.getLocationVotes().get(0).getDepartureLocation()).isEqualTo("서울시 송파구");
+        }
+
+        @Test
+        @DisplayName("participantId의 참여자가 이미 출발지를 등록했으면 DUPLICATE_LOCATION_VOTE 예외가 발생한다")
+        void createLocationVote_participantAlreadyVoted_throwsDuplicateLocationVote() {
+            // given
+            String meetingId = "meeting-id-555";
+            Meeting meeting = Meeting.ofId(meetingId);
+            LocationPoll locationPoll = LocationPoll.ofId(1L);
+            meeting.addPolls(null, locationPoll);
+            Participant participant = Participant.of(meeting, "friend-key", "친구");
+            ReflectionTestUtils.setField(participant, "id", 10L);
+            participant.addLocationVote(LocationVote.of(
+                    locationPoll, "친구", "서울시 강동구",
+                    new BigDecimal("37.5301930"), new BigDecimal("127.1237560")
+            ));
+            meeting.addParticipant(participant);
+
+            CreateLocationVoteRequest request = new CreateLocationVoteRequest(
+                    meetingId,
+                    "host-key",
+                    10L,
+                    "친구",
+                    "서울시 송파구",
+                    "37.5145430",
+                    "127.1058860"
+            );
+
+            when(meetingRepository.findByIdWithAllAssociations(meetingId)).thenReturn(Optional.of(meeting));
+
+            // when & then
+            assertThatThrownBy(() -> locationService.createLocationVote(request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DUPLICATE_LOCATION_VOTE);
+        }
+
+        @Test
+        @DisplayName("모임에 없는 participantId 지정 시 PARTICIPANT_NOT_FOUND 예외가 발생한다")
+        void createLocationVote_participantNotInMeeting_throwsParticipantNotFound() {
+            // given
+            String meetingId = "meeting-id-555";
+            Meeting meeting = Meeting.ofId(meetingId);
+
+            CreateLocationVoteRequest request = new CreateLocationVoteRequest(
+                    meetingId,
+                    "host-key",
+                    999L,
+                    "친구",
+                    "서울시 송파구",
+                    "37.5145430",
+                    "127.1058860"
+            );
+
+            when(meetingRepository.findByIdWithAllAssociations(meetingId)).thenReturn(Optional.of(meeting));
+
+            // when & then
+            assertThatThrownBy(() -> locationService.createLocationVote(request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_NOT_FOUND);
+        }
     }
 
     @Nested
@@ -226,6 +397,7 @@ class LocationVoteUnitTest {
         void createLocationVote_outOfServiceArea_throwsException() {
             CreateLocationVoteRequest request = new CreateLocationVoteRequest(
                     "meeting-id-123",
+                    null,
                     null,
                     "홍길동",
                     "경북 울릉군 독도",
@@ -247,6 +419,7 @@ class LocationVoteUnitTest {
             CreateLocationVoteRequest request = new CreateLocationVoteRequest(
                     "meeting-id-123",
                     null,
+                    null,
                     "홍길동",
                     "제주특별자치도 제주시",
                     "33.4996",
@@ -263,6 +436,7 @@ class LocationVoteUnitTest {
         void createLocationVote_nonNumericCoordinates_throwsException() {
             CreateLocationVoteRequest request = new CreateLocationVoteRequest(
                     "meeting-id-123",
+                    null,
                     null,
                     "홍길동",
                     "서울시 강남구",
@@ -297,17 +471,24 @@ class LocationVoteUnitTest {
     class DuplicateLocalStorageKey {
 
         @Test
-        @DisplayName("일반 참여자가 이미 존재하는 localStorageKey로 요청 시 DUPLICATE_LOCAL_STORAGE_KEY 예외가 발생한다")
-        void createLocationVote_duplicateKeyForNonHost_throwsDuplicateException() {
+        @DisplayName("이미 출발지를 등록한 참여자가 같은 localStorageKey로 재요청 시 DUPLICATE_LOCAL_STORAGE_KEY 예외가 발생한다")
+        void createLocationVote_duplicateKeyForAlreadyVoted_throwsDuplicateException() {
             // given
             String meetingId = "meeting-id-123";
             Meeting meeting = Meeting.ofId(meetingId);
+            LocationPoll locationPoll = LocationPoll.ofId(1L);
+            meeting.addPolls(null, locationPoll);
             Participant existingParticipant = Participant.of(meeting, "duplicate-key", "기존참여자");
+            existingParticipant.addLocationVote(LocationVote.of(
+                    locationPoll, "기존참여자", "서울시 강북구",
+                    new BigDecimal("37.6396320"), new BigDecimal("127.0256320")
+            ));
             meeting.addParticipant(existingParticipant);
 
             CreateLocationVoteRequest request = new CreateLocationVoteRequest(
                     meetingId,
                     "duplicate-key",
+                    null,
                     "새참여자",
                     "서울시 강남구",
                     "37.4979502",


### PR DESCRIPTION
## Issue Number
closed #144

## As-Is
- 일정 투표로 이미 Participant가 생성된 일반 참여자가 자기 `localStorageKey`로 출발지를 등록하면, 기존 참여자 분기가 방장만 허용(`!host.isHost()`)해서 무조건 `DUPLICATE_LOCAL_STORAGE_KEY`(E413)로 실패했습니다.
- 대리 추가(키 없음)로 저장된 출발지는 Participant와 연결되지 않아 `RouteDto.participantId`가 null로 내려가고, `participantId` 기반 개인 경로 조회 API를 사용할 수 없었습니다.
- 방장 첫 등록 시 `host.updateName(request.participantName())`이 실행되어, 다른 참여자 이름으로 요청이 오면 방장 이름이 덮어써졌습니다.

## To-Be
- `CreateLocationVoteRequest`에 `participantId`(선택) 필드 추가: 지정한 기존 참여자에게 출발지 투표를 연결합니다. 해당 참여자가 이미 출발지를 등록했으면 신규 에러 코드 `DUPLICATE_LOCATION_VOTE`(E430, 409)로 거부하고, 모임에 없는 참여자면 `PARTICIPANT_NOT_FOUND`(E414)를 반환합니다.
- 기존 참여자 분기의 방장 제한 완화: 출발지 미등록 상태의 참여자(방장/일반 무관)는 본인 키로 등록 가능. 중복 에러는 "이미 출발지를 등록한 경우"에만 발생합니다.
- `updateName` 이름 덮어쓰기 부작용 제거.
- Swagger 문서(`CreateLocationVoteApiDocs`)에 404 참여자 없음 / 409 중복 응답 예시 추가.

### 분기 정리 (createLocationVote)
| 요청 | 동작 |
| - | - |
| `participantId` 지정 | 해당 참여자에 투표 연결 (이미 등록 시 E430) |
| 키 일치 참여자 존재 + 출발지 없음 | 그 참여자에 투표 연결 |
| 키 일치 참여자 존재 + 출발지 있음 | E413 |
| 키 있음 + 일치 참여자 없음 | 신규 Participant 생성 (기존 동일) |
| 키 없음 | 참가자 미연결 수동 추가 (기존 동일) |

## Review Request (중요)
- 코드 리뷰는 **한국어로 작성**해주세요.
- `participantId` 분기가 `localStorageKey` 분기보다 우선하는 설계가 적절한지 봐주세요.
- 프론트 대응 PR: dnd-side-project/dnd-14th-8-frontend#129 이슈 기반 작업과 규약을 맞췄습니다.

## Check List
- [x] 테스트가 전부 통과되었나요? (`./gradlew clean test` — 유닛 5개/통합 2개 신규 포함 전체 통과)
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요? (base: `dev`)
- [ ] Assignee를 지정했나요?
- [ ] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요? (#144)

## (Optional) Additional Description
🤖 Generated with [Claude Code](https://claude.com/claude-code)
