### PR TITLE
랜딩 오늘 생성된 모임 수 API 추가

### DIFF
--- a/src/main/java/com/dnd/moyeolak/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/dnd/moyeolak/domain/meeting/controller/MeetingController.java
@@ -3,6 +3,7 @@ package com.dnd.moyeolak.domain.meeting.controller;
 import com.dnd.moyeolak.domain.meeting.dto.CreateMeetingRequest;
 import com.dnd.moyeolak.domain.meeting.dto.GetMeetingScheduleResponse;
 import com.dnd.moyeolak.domain.meeting.dto.GetMeetingScheduleVoteResultResponse;
+import com.dnd.moyeolak.domain.meeting.dto.LandingStatsResponse;
 import com.dnd.moyeolak.domain.meeting.dto.UpdateMeetingRequest;
 import com.dnd.moyeolak.domain.meeting.service.MeetingService;
 import com.dnd.moyeolak.global.response.ApiResponse;
@@ -31,6 +32,13 @@ public class MeetingController {
     public ResponseEntity<ApiResponse<List<String>>> getAllMeetings() {
         List<String> allMeetings = meetingService.findAllMeetings();
         return ResponseEntity.ok(ApiResponse.success(allMeetings));
+    }
+
+    @GetMapping("/stats")
+    @Operation(summary = "랜딩 통계 조회", description = "랜딩 화면에 표시할 오늘 생성된 모임 수를 조회합니다.")
+    public ResponseEntity<ApiResponse<LandingStatsResponse>> getLandingStats() {
+        LandingStatsResponse stats = meetingService.getLandingStats();
+        return ResponseEntity.ok(ApiResponse.success(stats));
     }
 
     @GetMapping("/{meetingId}/schedules")

--- a/src/main/java/com/dnd/moyeolak/domain/meeting/dto/LandingStatsResponse.java
+++ b/src/main/java/com/dnd/moyeolak/domain/meeting/dto/LandingStatsResponse.java
@@ -1,0 +1,6 @@
+package com.dnd.moyeolak.domain.meeting.dto;
+
+public record LandingStatsResponse(
+        long todayCreatedMeetingCount
+) {
+}

--- a/src/main/java/com/dnd/moyeolak/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/dnd/moyeolak/domain/meeting/repository/MeetingRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,4 +24,9 @@ public interface MeetingRepository extends JpaRepository<Meeting, String> {
         SELECT m.id FROM Meeting m
     """)
     List<String> findAllMeetingsId();
+
+    long countByCreatedAtGreaterThanEqualAndCreatedAtLessThan(
+            LocalDateTime startInclusive,
+            LocalDateTime endExclusive
+    );
 }

--- a/src/main/java/com/dnd/moyeolak/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/dnd/moyeolak/domain/meeting/service/MeetingService.java
@@ -3,6 +3,7 @@ package com.dnd.moyeolak.domain.meeting.service;
 import com.dnd.moyeolak.domain.meeting.dto.CreateMeetingRequest;
 import com.dnd.moyeolak.domain.meeting.dto.GetMeetingScheduleResponse;
 import com.dnd.moyeolak.domain.meeting.dto.GetMeetingScheduleVoteResultResponse;
+import com.dnd.moyeolak.domain.meeting.dto.LandingStatsResponse;
 import com.dnd.moyeolak.domain.meeting.dto.UpdateMeetingRequest;
 import com.dnd.moyeolak.domain.meeting.entity.Meeting;
 
@@ -19,6 +20,8 @@ public interface MeetingService {
     GetMeetingScheduleResponse getMeetingSchedules(String meetingId);
 
     GetMeetingScheduleVoteResultResponse getMeetingScheduleVoteResults(String meetingId);
+
+    LandingStatsResponse getLandingStats();
 
     List<String> findAllMeetings();
 

--- a/src/main/java/com/dnd/moyeolak/domain/meeting/service/impl/MeetingServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/meeting/service/impl/MeetingServiceImpl.java
@@ -4,6 +4,7 @@ import com.dnd.moyeolak.domain.location.entity.LocationPoll;
 import com.dnd.moyeolak.domain.meeting.dto.CreateMeetingRequest;
 import com.dnd.moyeolak.domain.meeting.dto.GetMeetingScheduleResponse;
 import com.dnd.moyeolak.domain.meeting.dto.GetMeetingScheduleVoteResultResponse;
+import com.dnd.moyeolak.domain.meeting.dto.LandingStatsResponse;
 import com.dnd.moyeolak.domain.meeting.dto.UpdateMeetingRequest;
 import com.dnd.moyeolak.domain.meeting.entity.Meeting;
 import com.dnd.moyeolak.domain.meeting.repository.MeetingRepository;
@@ -20,6 +21,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -30,6 +34,7 @@ public class MeetingServiceImpl implements MeetingService {
     private final MeetingRepository meetingRepository;
     private final ParticipantService participantService;
     private final ScheduleVoteService scheduleVoteService;
+    private final Clock clock;
 
     @Override
     @Transactional
@@ -93,6 +98,20 @@ public class MeetingServiceImpl implements MeetingService {
          *  - 예시: 일정 옵션 A: 3명, 일정 옵션 B: 5명, 일정 옵션 C: 2명
          */
         return GetMeetingScheduleVoteResultResponse.of(participantCount, participantNames, scheduleVotes);
+    }
+
+    @Override
+    public LandingStatsResponse getLandingStats() {
+        LocalDate today = LocalDate.now(clock);
+        LocalDateTime startInclusive = today.atStartOfDay();
+        LocalDateTime endExclusive = today.plusDays(1).atStartOfDay();
+
+        long todayCreatedMeetingCount = meetingRepository.countByCreatedAtGreaterThanEqualAndCreatedAtLessThan(
+                startInclusive,
+                endExclusive
+        );
+
+        return new LandingStatsResponse(todayCreatedMeetingCount);
     }
 
     @Override

--- a/src/test/java/com/dnd/moyeolak/domain/meeting/controller/MeetingControllerTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/meeting/controller/MeetingControllerTest.java
@@ -1,0 +1,54 @@
+package com.dnd.moyeolak.domain.meeting.controller;
+
+import com.dnd.moyeolak.domain.meeting.dto.LandingStatsResponse;
+import com.dnd.moyeolak.domain.meeting.service.MeetingService;
+import com.dnd.moyeolak.global.exception.GlobalExceptionAdvice;
+import com.dnd.moyeolak.global.response.SuccessCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingControllerTest {
+
+    @Mock
+    private MeetingService meetingService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        MeetingController controller = new MeetingController(meetingService);
+        this.mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionAdvice())
+                .build();
+    }
+
+    @Test
+    @DisplayName("랜딩 통계 조회 API는 오늘 생성된 모임 수를 반환한다")
+    void getLandingStats_returnsTodayCreatedMeetingCount() throws Exception {
+        // given
+        when(meetingService.getLandingStats()).thenReturn(new LandingStatsResponse(128L));
+
+        // when & then
+        mockMvc.perform(get("/api/meetings/stats"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(SuccessCode.OK.getCode()))
+                .andExpect(jsonPath("$.data.todayCreatedMeetingCount").value(128));
+
+        verify(meetingService).getLandingStats();
+    }
+}

--- a/src/test/java/com/dnd/moyeolak/domain/meeting/service/MeetingServiceUnitTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/meeting/service/MeetingServiceUnitTest.java
@@ -18,8 +18,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -34,6 +37,9 @@ class MeetingServiceUnitTest {
 
     @Mock
     private MeetingRepository meetingRepository;
+
+    @Mock
+    private Clock clock;
 
     @InjectMocks
     private MeetingServiceImpl meetingService;
@@ -165,6 +171,25 @@ class MeetingServiceUnitTest {
         assertThatThrownBy(() -> meetingService.deleteMeeting(meetingId))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.MEETING_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("랜딩 통계 조회 시 오늘 생성된 모임 수가 반환된다")
+    void getLandingStats_returnsTodayCreatedMeetingCount() {
+        // given
+        ZoneId zoneId = ZoneId.of("Asia/Seoul");
+        when(clock.instant()).thenReturn(Instant.parse("2026-07-18T03:15:00Z"));
+        when(clock.getZone()).thenReturn(zoneId);
+        when(meetingRepository.countByCreatedAtGreaterThanEqualAndCreatedAtLessThan(
+                LocalDateTime.of(2026, 7, 18, 0, 0),
+                LocalDateTime.of(2026, 7, 19, 0, 0)
+        )).thenReturn(128L);
+
+        // when
+        var response = meetingService.getLandingStats();
+
+        // then
+        assertThat(response.todayCreatedMeetingCount()).isEqualTo(128L);
     }
 
     private Meeting createMeetingWithAllAssociations() {


### PR DESCRIPTION
## Summary

- Add `GET /api/meetings/stats` for landing page stats.
- Return `todayCreatedMeetingCount` based on `Meeting.createdAt`.
- Calculate the date window with the injected `Clock` and count meetings from today 00:00 inclusive to tomorrow 00:00 exclusive.
- Add service and controller tests for the new API.

Closes #146

## Validation

- `./gradlew test`
