### PR TITLE
근거리 출발지 중간지점 결과 타입 추가

### DIFF
--- a/src/main/java/com/dnd/moyeolak/domain/location/docs/GetMidpointRecommendationsApiDocs.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/docs/GetMidpointRecommendationsApiDocs.java
@@ -71,6 +71,7 @@ import java.lang.annotation.Target;
                                                 "departureTime": "2026-02-18T10:30:00",
                                                 "registeredCount": 4,
                                                 "totalCount": 10,
+                                                "resultType": "NORMAL",
                                                 "recommendations": [
                                                   {
                                                     "rank": 1,

--- a/src/main/java/com/dnd/moyeolak/domain/location/dto/MidpointRecommendationResponse.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/dto/MidpointRecommendationResponse.java
@@ -1,5 +1,6 @@
 package com.dnd.moyeolak.domain.location.dto;
 
+import com.dnd.moyeolak.domain.location.enums.MidpointResultType;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -22,5 +23,8 @@ public record MidpointRecommendationResponse(
         int registeredCount,
 
         @Schema(description = "전체 참여자 수", example = "10")
-        int totalCount
+        int totalCount,
+
+        @Schema(description = "중간지점 추천 결과 타입", example = "NORMAL")
+        MidpointResultType resultType
 ) {}

--- a/src/main/java/com/dnd/moyeolak/domain/location/enums/MidpointResultType.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/enums/MidpointResultType.java
@@ -1,0 +1,12 @@
+package com.dnd.moyeolak.domain.location.enums;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "중간지점 추천 결과 타입")
+public enum MidpointResultType {
+    @Schema(description = "일반 중간지점 추천")
+    NORMAL,
+
+    @Schema(description = "출발지가 이미 가까워 후보역 간 이동시간 차이가 작은 추천")
+    NEARBY_DEPARTURES
+}

--- a/src/main/java/com/dnd/moyeolak/domain/location/service/impl/MidpointRecommendationServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/service/impl/MidpointRecommendationServiceImpl.java
@@ -3,6 +3,7 @@ package com.dnd.moyeolak.domain.location.service.impl;
 import com.dnd.moyeolak.domain.location.dto.*;
 import com.dnd.moyeolak.domain.location.entity.LocationPoll;
 import com.dnd.moyeolak.domain.location.entity.LocationVote;
+import com.dnd.moyeolak.domain.location.enums.MidpointResultType;
 import com.dnd.moyeolak.domain.location.repository.LocationVoteRepository;
 import com.dnd.moyeolak.domain.location.service.MidpointRecommendationService;
 import com.dnd.moyeolak.domain.meeting.entity.Meeting;
@@ -45,6 +46,8 @@ public class MidpointRecommendationServiceImpl implements MidpointRecommendation
     private static final int SEARCH_RADIUS_METERS = 5000;
     private static final int MAX_CANDIDATE_STATIONS = 10;
     private static final int TOP_RECOMMENDATIONS = 3;
+    private static final int NEARBY_MAX_ROUTE_DURATION_MINUTES = 15;
+    private static final int NEARBY_MAX_AVG_DURATION_GAP_MINUTES = 5;
     // KakaoDirectionsClient의 Semaphore 허용치(5)에 맞춘 병렬도 — 더 늘려도 세마포어에서 대기만 한다
     private static final int DRIVING_ENRICHMENT_THREADS = 5;
 
@@ -98,11 +101,40 @@ public class MidpointRecommendationServiceImpl implements MidpointRecommendation
 
         // 6. Top 3에만 Kakao 자동차 경로 보강 후 응답 조립
         List<StationRecommendationDto> recommendations = buildRecommendations(votes, topStations, departureTime);
+        MidpointResultType resultType = resolveResultType(recommendations);
 
         return new MidpointRecommendationResponse(
                 centerPoint, recommendations, departureTime,
-                votes.size(), meeting.getParticipantCount()
+                votes.size(), meeting.getParticipantCount(), resultType
         );
+    }
+
+    private MidpointResultType resolveResultType(List<StationRecommendationDto> recommendations) {
+        if (recommendations.size() < 2) {
+            return MidpointResultType.NORMAL;
+        }
+
+        StationRecommendationDto topStation = recommendations.getFirst();
+        boolean allRoutesReachable = topStation.routes().stream()
+                .allMatch(RouteDto::transitReachable);
+        boolean allRoutesShort = topStation.routes().stream()
+                .allMatch(route -> route.transitDuration() <= NEARBY_MAX_ROUTE_DURATION_MINUTES);
+        double minAvgDuration = recommendations.stream()
+                .mapToDouble(StationRecommendationDto::avgTransitDuration)
+                .min()
+                .orElse(Double.MAX_VALUE);
+        double maxAvgDuration = recommendations.stream()
+                .mapToDouble(StationRecommendationDto::avgTransitDuration)
+                .max()
+                .orElse(Double.MAX_VALUE);
+
+        if (allRoutesReachable
+                && allRoutesShort
+                && maxAvgDuration - minAvgDuration <= NEARBY_MAX_AVG_DURATION_GAP_MINUTES) {
+            return MidpointResultType.NEARBY_DEPARTURES;
+        }
+
+        return MidpointResultType.NORMAL;
     }
 
     private CenterPointDto calculateCentroid(List<LocationVote> votes) {

--- a/src/test/java/com/dnd/moyeolak/domain/location/service/MidpointRecommendationServiceImplTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/location/service/MidpointRecommendationServiceImplTest.java
@@ -318,6 +318,68 @@ class MidpointRecommendationServiceImplTest {
         }
 
         @Test
+        @DisplayName("추천 후보 간 평균 시간이 비슷하고 모두 15분 이내이면 근거리 출발지 결과 타입을 반환한다")
+        void returnsNearbyDeparturesResultTypeForShortSimilarRoutes() {
+            mockMeetingWithLocationPoll();
+            LocationVote vote1 = createMockVote("37.5550", "126.9100", "참가자A", "합정역");
+            LocationVote vote2 = createMockVote("37.5570", "126.9240", "참가자B", "홍대입구역");
+            when(locationVoteRepository.findByLocationPoll_Id(1L)).thenReturn(List.of(vote1, vote2));
+            when(stationRepository.calculateCentroid(any())).thenThrow(new RuntimeException("PostGIS 미지원"));
+            List<Station> stations = List.of(
+                    createMockStation(1L, "합정역", "2호선", 37.5495, 126.9137),
+                    createMockStation(2L, "홍대입구역", "2호선", 37.5572, 126.9245),
+                    createMockStation(3L, "상수역", "6호선", 37.5477, 126.9229)
+            );
+            when(stationRepository.findNearbyStations(anyDouble(), anyDouble(), anyInt(), anyInt()))
+                    .thenReturn(stations);
+            when(googleRoutesClient.computeTransitMatrix(anyList(), anyList(), any()))
+                    .thenReturn(List.of(
+                            List.of(new TransitRouteResult(8, 1000, true), new TransitRouteResult(10, 1300, true),
+                                    new TransitRouteResult(11, 1400, true)),
+                            List.of(new TransitRouteResult(9, 1100, true), new TransitRouteResult(8, 900, true),
+                                    new TransitRouteResult(12, 1500, true))
+                    ));
+            when(kakaoDirectionsClient.requestDrivingRoute(anyDouble(), anyDouble(), anyDouble(), anyDouble(), any()))
+                    .thenReturn(new KakaoDirectionsResponse.Summary(2500, 480, null));
+
+            MidpointRecommendationResponse response =
+                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null);
+
+            assertThat(response.resultType().name()).isEqualTo("NEARBY_DEPARTURES");
+        }
+
+        @Test
+        @DisplayName("추천 후보 간 평균 시간이 벌어지면 일반 중간지점 결과 타입을 반환한다")
+        void returnsNormalResultTypeWhenRecommendationDurationsDiffer() {
+            mockMeetingWithLocationPoll();
+            LocationVote vote1 = createMockVote("37.5000", "127.0000", "참가자A", "서울시 강남구");
+            LocationVote vote2 = createMockVote("37.6500", "126.7700", "참가자B", "경기 고양시");
+            when(locationVoteRepository.findByLocationPoll_Id(1L)).thenReturn(List.of(vote1, vote2));
+            when(stationRepository.calculateCentroid(any())).thenThrow(new RuntimeException("PostGIS 미지원"));
+            List<Station> stations = List.of(
+                    createMockStation(1L, "디지털미디어시티역", "공항철도", 37.5766, 126.9009),
+                    createMockStation(2L, "홍대입구역", "2호선", 37.5572, 126.9245),
+                    createMockStation(3L, "강남역", "2호선", 37.4979, 127.0276)
+            );
+            when(stationRepository.findNearbyStations(anyDouble(), anyDouble(), anyInt(), anyInt()))
+                    .thenReturn(stations);
+            when(googleRoutesClient.computeTransitMatrix(anyList(), anyList(), any()))
+                    .thenReturn(List.of(
+                            List.of(new TransitRouteResult(30, 9000, true), new TransitRouteResult(45, 12000, true),
+                                    new TransitRouteResult(70, 20000, true)),
+                            List.of(new TransitRouteResult(34, 10000, true), new TransitRouteResult(52, 15000, true),
+                                    new TransitRouteResult(80, 24000, true))
+                    ));
+            when(kakaoDirectionsClient.requestDrivingRoute(anyDouble(), anyDouble(), anyDouble(), anyDouble(), any()))
+                    .thenReturn(new KakaoDirectionsResponse.Summary(12000, 1800, null));
+
+            MidpointRecommendationResponse response =
+                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null);
+
+            assertThat(response.resultType().name()).isEqualTo("NORMAL");
+        }
+
+        @Test
         @DisplayName("departureName이 없으면 participant 이름으로 대체한다")
         void usesParticipantNameWhenDepartureNameIsNull() {
             mockMeetingWithLocationPoll();


### PR DESCRIPTION
## 변경 사항

- 중간지점 추천 응답에 `resultType`을 추가했습니다.
- `MidpointResultType.NORMAL`, `MidpointResultType.NEARBY_DEPARTURES` enum을 추가했습니다.
- 추천 후보 간 평균 대중교통 시간이 비슷하고 1순위 추천역 기준 모든 참여자가 15분 이내로 도달 가능한 경우 `NEARBY_DEPARTURES`를 반환하도록 했습니다.
- Swagger 예시 응답에 `resultType`을 반영했습니다.
- 근거리/일반 결과 타입 판별 테스트를 추가했습니다.

## 배경

합정역, 홍대입구역처럼 참여자 출발지가 이미 가까운 경우에는 일반적인 중간지점 결과보다 "가까운 후보 중 편한 역 선택"이라는 UX가 더 자연스럽습니다. 프론트가 이를 안정적으로 표현할 수 있도록 API 응답에 결과 타입을 내려줍니다.

현재 `stations` 테이블에는 역 인접 그래프가 없으므로, 1차 구현은 이미 계산 중인 대중교통 이동시간과 후보역 간 평균 시간 차이를 기준으로 판별합니다.

## 판별 기준

`NEARBY_DEPARTURES` 조건:

- 추천 후보가 2개 이상
- 1순위 추천역 기준 모든 참여자의 대중교통 경로가 도달 가능
- 1순위 추천역 기준 모든 참여자의 대중교통 이동시간이 15분 이하
- 추천 후보들의 평균 대중교통 이동시간 차이가 5분 이하

그 외는 `NORMAL`로 응답합니다.

Closes #148

## 검증

- `./gradlew test --tests com.dnd.moyeolak.domain.location.service.MidpointRecommendationServiceImplTest`
- `./gradlew test`
- `./gradlew build`
