### PR TITLE
근거리 중간지점 판정 기준 보정

### DIFF
--- a/src/main/java/com/dnd/moyeolak/domain/location/service/impl/MidpointRecommendationServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/service/impl/MidpointRecommendationServiceImpl.java
@@ -247,10 +247,6 @@ public class MidpointRecommendationServiceImpl implements MidpointRecommendation
     }
 
     private TransitRouteResult resolveTransitRoute(LocationVote vote, Station station, TransitRouteResult transitRoute) {
-        if (transitRoute.reachable()) {
-            return transitRoute;
-        }
-
         int distanceToStation = haversineDistance(
                 vote.getDepartureLat().doubleValue(),
                 vote.getDepartureLng().doubleValue(),
@@ -262,6 +258,10 @@ public class MidpointRecommendationServiceImpl implements MidpointRecommendation
         }
 
         int walkingDuration = Math.max(1, (int) Math.ceil(distanceToStation / (double) WALKING_SPEED_METERS_PER_MINUTE));
+        if (transitRoute.reachable() && transitRoute.durationMinutes() <= walkingDuration) {
+            return transitRoute;
+        }
+
         return new TransitRouteResult(walkingDuration, distanceToStation, true);
     }
 

--- a/src/main/java/com/dnd/moyeolak/domain/location/service/impl/MidpointRecommendationServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/service/impl/MidpointRecommendationServiceImpl.java
@@ -48,6 +48,8 @@ public class MidpointRecommendationServiceImpl implements MidpointRecommendation
     private static final int TOP_RECOMMENDATIONS = 3;
     private static final int NEARBY_MAX_ROUTE_DURATION_MINUTES = 15;
     private static final int NEARBY_MAX_DEPARTURE_DISTANCE_METERS = 2000;
+    private static final int WALKABLE_STATION_DISTANCE_METERS = 700;
+    private static final int WALKING_SPEED_METERS_PER_MINUTE = 80;
     // KakaoDirectionsClient의 Semaphore 허용치(5)에 맞춘 병렬도 — 더 늘려도 세마포어에서 대기만 한다
     private static final int DRIVING_ENRICHMENT_THREADS = 5;
 
@@ -192,7 +194,9 @@ public class MidpointRecommendationServiceImpl implements MidpointRecommendation
             Station station = stations.get(stationIdx);
             List<TransitRouteResult> transitRoutes = new ArrayList<>();
             for (int voteIdx = 0; voteIdx < votes.size(); voteIdx++) {
-                transitRoutes.add(transitMatrix.get(voteIdx).get(stationIdx));
+                LocationVote vote = votes.get(voteIdx);
+                TransitRouteResult transitRoute = transitMatrix.get(voteIdx).get(stationIdx);
+                transitRoutes.add(resolveTransitRoute(vote, station, transitRoute));
             }
 
             List<TransitRouteResult> reachableRoutes = transitRoutes.stream()
@@ -224,13 +228,41 @@ public class MidpointRecommendationServiceImpl implements MidpointRecommendation
             throw new BusinessException(ErrorCode.NO_REACHABLE_STATIONS);
         }
 
+        Comparator<StationEvaluation> comparator = Comparator.comparingInt(StationEvaluation::unreachableTransitRouteCount);
+        if (areDeparturesClose(votes)) {
+            comparator = comparator
+                    .thenComparingInt(StationEvaluation::distanceFromCenter)
+                    .thenComparingDouble(StationEvaluation::avgTransitDuration);
+        } else {
+            comparator = comparator
+                    .thenComparingDouble(StationEvaluation::avgTransitDuration)
+                    .thenComparingInt(StationEvaluation::distanceFromCenter);
+        }
+
         // 도달 불가 참가자가 적은 역이 우선 — 일부만 갈 수 있는 역이 짧은 평균만으로 1위가 되지 않도록
         return evaluations.stream()
-                .sorted(Comparator.comparingInt(StationEvaluation::unreachableTransitRouteCount)
-                        .thenComparingDouble(StationEvaluation::avgTransitDuration)
-                        .thenComparingInt(StationEvaluation::distanceFromCenter))
+                .sorted(comparator)
                 .limit(TOP_RECOMMENDATIONS)
                 .toList();
+    }
+
+    private TransitRouteResult resolveTransitRoute(LocationVote vote, Station station, TransitRouteResult transitRoute) {
+        if (transitRoute.reachable()) {
+            return transitRoute;
+        }
+
+        int distanceToStation = haversineDistance(
+                vote.getDepartureLat().doubleValue(),
+                vote.getDepartureLng().doubleValue(),
+                station.getLatitude(),
+                station.getLongitude()
+        );
+        if (distanceToStation > WALKABLE_STATION_DISTANCE_METERS) {
+            return transitRoute;
+        }
+
+        int walkingDuration = Math.max(1, (int) Math.ceil(distanceToStation / (double) WALKING_SPEED_METERS_PER_MINUTE));
+        return new TransitRouteResult(walkingDuration, distanceToStation, true);
     }
 
     private List<StationRecommendationDto> buildRecommendations(

--- a/src/main/java/com/dnd/moyeolak/domain/location/service/impl/MidpointRecommendationServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/service/impl/MidpointRecommendationServiceImpl.java
@@ -47,7 +47,7 @@ public class MidpointRecommendationServiceImpl implements MidpointRecommendation
     private static final int MAX_CANDIDATE_STATIONS = 10;
     private static final int TOP_RECOMMENDATIONS = 3;
     private static final int NEARBY_MAX_ROUTE_DURATION_MINUTES = 15;
-    private static final int NEARBY_MAX_AVG_DURATION_GAP_MINUTES = 5;
+    private static final int NEARBY_MAX_DEPARTURE_DISTANCE_METERS = 2000;
     // KakaoDirectionsClient의 Semaphore 허용치(5)에 맞춘 병렬도 — 더 늘려도 세마포어에서 대기만 한다
     private static final int DRIVING_ENRICHMENT_THREADS = 5;
 
@@ -101,7 +101,7 @@ public class MidpointRecommendationServiceImpl implements MidpointRecommendation
 
         // 6. Top 3에만 Kakao 자동차 경로 보강 후 응답 조립
         List<StationRecommendationDto> recommendations = buildRecommendations(votes, topStations, departureTime);
-        MidpointResultType resultType = resolveResultType(recommendations);
+        MidpointResultType resultType = resolveResultType(votes, recommendations);
 
         return new MidpointRecommendationResponse(
                 centerPoint, recommendations, departureTime,
@@ -109,8 +109,8 @@ public class MidpointRecommendationServiceImpl implements MidpointRecommendation
         );
     }
 
-    private MidpointResultType resolveResultType(List<StationRecommendationDto> recommendations) {
-        if (recommendations.size() < 2) {
+    private MidpointResultType resolveResultType(List<LocationVote> votes, List<StationRecommendationDto> recommendations) {
+        if (votes.size() < 2 || recommendations.isEmpty()) {
             return MidpointResultType.NORMAL;
         }
 
@@ -119,22 +119,34 @@ public class MidpointRecommendationServiceImpl implements MidpointRecommendation
                 .allMatch(RouteDto::transitReachable);
         boolean allRoutesShort = topStation.routes().stream()
                 .allMatch(route -> route.transitDuration() <= NEARBY_MAX_ROUTE_DURATION_MINUTES);
-        double minAvgDuration = recommendations.stream()
-                .mapToDouble(StationRecommendationDto::avgTransitDuration)
-                .min()
-                .orElse(Double.MAX_VALUE);
-        double maxAvgDuration = recommendations.stream()
-                .mapToDouble(StationRecommendationDto::avgTransitDuration)
-                .max()
-                .orElse(Double.MAX_VALUE);
+        boolean departuresClose = areDeparturesClose(votes);
 
         if (allRoutesReachable
                 && allRoutesShort
-                && maxAvgDuration - minAvgDuration <= NEARBY_MAX_AVG_DURATION_GAP_MINUTES) {
+                && departuresClose) {
             return MidpointResultType.NEARBY_DEPARTURES;
         }
 
         return MidpointResultType.NORMAL;
+    }
+
+    private boolean areDeparturesClose(List<LocationVote> votes) {
+        for (int i = 0; i < votes.size(); i++) {
+            LocationVote source = votes.get(i);
+            for (int j = i + 1; j < votes.size(); j++) {
+                LocationVote target = votes.get(j);
+                int distance = haversineDistance(
+                        source.getDepartureLat().doubleValue(),
+                        source.getDepartureLng().doubleValue(),
+                        target.getDepartureLat().doubleValue(),
+                        target.getDepartureLng().doubleValue()
+                );
+                if (distance > NEARBY_MAX_DEPARTURE_DISTANCE_METERS) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     private CenterPointDto calculateCentroid(List<LocationVote> votes) {

--- a/src/test/java/com/dnd/moyeolak/domain/location/service/MidpointRecommendationServiceImplTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/location/service/MidpointRecommendationServiceImplTest.java
@@ -380,6 +380,73 @@ class MidpointRecommendationServiceImplTest {
         }
 
         @Test
+        @DisplayName("출발지가 같은 역 근처에 모여 있으면 중심점에 가장 가까운 역을 우선 추천한다")
+        void prefersNearestStationToCenterWhenDeparturesAreClose() {
+            mockMeetingWithLocationPoll();
+            LocationVote vote1 = createMockVote("37.5572", "126.9245", "참가자A", "홍대입구역");
+            LocationVote vote2 = createMockVote("37.5573", "126.9246", "참가자B", "홍대입구역");
+            when(locationVoteRepository.findByLocationPoll_Id(1L)).thenReturn(List.of(vote1, vote2));
+            when(stationRepository.calculateCentroid(any())).thenThrow(new RuntimeException("PostGIS 미지원"));
+            List<Station> stations = List.of(
+                    createMockStation(1L, "신촌역", "2호선", 37.5551, 126.9368),
+                    createMockStation(2L, "합정역", "2호선", 37.5495, 126.9137),
+                    createMockStation(3L, "홍대입구역", "2호선", 37.5572, 126.9245)
+            );
+            when(stationRepository.findNearbyStations(anyDouble(), anyDouble(), anyInt(), anyInt()))
+                    .thenReturn(stations);
+            when(googleRoutesClient.computeTransitMatrix(anyList(), anyList(), any()))
+                    .thenReturn(List.of(
+                            List.of(new TransitRouteResult(4, 900, true), new TransitRouteResult(5, 1000, true),
+                                    new TransitRouteResult(12, 100, true)),
+                            List.of(new TransitRouteResult(4, 900, true), new TransitRouteResult(5, 1000, true),
+                                    new TransitRouteResult(12, 100, true))
+                    ));
+            when(kakaoDirectionsClient.requestDrivingRoute(anyDouble(), anyDouble(), anyDouble(), anyDouble(), any()))
+                    .thenReturn(new KakaoDirectionsResponse.Summary(1200, 300, null));
+
+            MidpointRecommendationResponse response =
+                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null);
+
+            assertThat(response.recommendations()).extracting("stationName")
+                    .containsExactly("홍대입구역", "신촌역", "합정역");
+            assertThat(response.resultType().name()).isEqualTo("NEARBY_DEPARTURES");
+        }
+
+        @Test
+        @DisplayName("출발지가 역 바로 근처이면 대중교통 매트릭스가 누락되어도 도보 경로로 보정한다")
+        void treatsVeryCloseUnreachableTransitRoutesAsWalkable() {
+            mockMeetingWithLocationPoll();
+            LocationVote vote1 = createMockVote("37.5572", "126.9245", "참가자A", "홍대입구역");
+            LocationVote vote2 = createMockVote("37.5573", "126.9246", "참가자B", "홍대입구역");
+            when(locationVoteRepository.findByLocationPoll_Id(1L)).thenReturn(List.of(vote1, vote2));
+            when(stationRepository.calculateCentroid(any())).thenThrow(new RuntimeException("PostGIS 미지원"));
+            List<Station> stations = List.of(
+                    createMockStation(1L, "신촌역", "2호선", 37.5551, 126.9368),
+                    createMockStation(2L, "합정역", "2호선", 37.5495, 126.9137),
+                    createMockStation(3L, "홍대입구역", "2호선", 37.5572, 126.9245)
+            );
+            when(stationRepository.findNearbyStations(anyDouble(), anyDouble(), anyInt(), anyInt()))
+                    .thenReturn(stations);
+            when(googleRoutesClient.computeTransitMatrix(anyList(), anyList(), any()))
+                    .thenReturn(List.of(
+                            List.of(new TransitRouteResult(4, 900, true), new TransitRouteResult(5, 1000, true),
+                                    TransitRouteResult.unreachable()),
+                            List.of(new TransitRouteResult(4, 900, true), new TransitRouteResult(5, 1000, true),
+                                    TransitRouteResult.unreachable())
+                    ));
+            when(kakaoDirectionsClient.requestDrivingRoute(anyDouble(), anyDouble(), anyDouble(), anyDouble(), any()))
+                    .thenReturn(new KakaoDirectionsResponse.Summary(1200, 300, null));
+
+            MidpointRecommendationResponse response =
+                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null);
+
+            StationRecommendationDto first = response.recommendations().getFirst();
+            assertThat(first.stationName()).isEqualTo("홍대입구역");
+            assertThat(first.routes()).extracting("transitReachable").containsExactly(true, true);
+            assertThat(first.routes()).extracting("transitDuration").containsExactly(1, 1);
+        }
+
+        @Test
         @DisplayName("출발지가 멀리 떨어져 있으면 일반 중간지점 결과 타입을 반환한다")
         void returnsNormalResultTypeWhenDeparturesAreFarApart() {
             mockMeetingWithLocationPoll();

--- a/src/test/java/com/dnd/moyeolak/domain/location/service/MidpointRecommendationServiceImplTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/location/service/MidpointRecommendationServiceImplTest.java
@@ -447,6 +447,41 @@ class MidpointRecommendationServiceImplTest {
         }
 
         @Test
+        @DisplayName("출발지가 역 바로 근처이면 대중교통 시간이 과도하게 길어도 도보 경로로 보정한다")
+        void shortensInflatedTransitRoutesWhenDepartureIsVeryCloseToStation() {
+            mockMeetingWithLocationPoll();
+            LocationVote vote1 = createMockVote("37.5572", "126.9245", "참가자A", "홍대입구역 2호선");
+            LocationVote vote2 = createMockVote("37.5570", "126.9269", "참가자B", "홍대입구역 공항철도");
+            when(locationVoteRepository.findByLocationPoll_Id(1L)).thenReturn(List.of(vote1, vote2));
+            when(stationRepository.calculateCentroid(any())).thenThrow(new RuntimeException("PostGIS 미지원"));
+            List<Station> stations = List.of(
+                    createMockStation(1L, "신촌역", "2호선", 37.5551, 126.9368),
+                    createMockStation(2L, "합정역", "2호선", 37.5495, 126.9137),
+                    createMockStation(3L, "홍대입구역", "2호선", 37.5572, 126.9245)
+            );
+            when(stationRepository.findNearbyStations(anyDouble(), anyDouble(), anyInt(), anyInt()))
+                    .thenReturn(stations);
+            when(googleRoutesClient.computeTransitMatrix(anyList(), anyList(), any()))
+                    .thenReturn(List.of(
+                            List.of(new TransitRouteResult(4, 900, true), new TransitRouteResult(5, 1000, true),
+                                    new TransitRouteResult(18, 0, true)),
+                            List.of(new TransitRouteResult(4, 900, true), new TransitRouteResult(5, 1000, true),
+                                    new TransitRouteResult(22, 0, true))
+                    ));
+            when(kakaoDirectionsClient.requestDrivingRoute(anyDouble(), anyDouble(), anyDouble(), anyDouble(), any()))
+                    .thenReturn(new KakaoDirectionsResponse.Summary(1200, 300, null));
+
+            MidpointRecommendationResponse response =
+                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null);
+
+            StationRecommendationDto first = response.recommendations().getFirst();
+            assertThat(first.stationName()).isEqualTo("홍대입구역");
+            assertThat(first.routes()).extracting("transitReachable").containsExactly(true, true);
+            assertThat(first.routes()).extracting("transitDuration").containsExactly(1, 3);
+            assertThat(response.resultType().name()).isEqualTo("NEARBY_DEPARTURES");
+        }
+
+        @Test
         @DisplayName("출발지가 멀리 떨어져 있으면 일반 중간지점 결과 타입을 반환한다")
         void returnsNormalResultTypeWhenDeparturesAreFarApart() {
             mockMeetingWithLocationPoll();

--- a/src/test/java/com/dnd/moyeolak/domain/location/service/MidpointRecommendationServiceImplTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/location/service/MidpointRecommendationServiceImplTest.java
@@ -349,8 +349,39 @@ class MidpointRecommendationServiceImplTest {
         }
 
         @Test
-        @DisplayName("추천 후보 간 평균 시간이 벌어지면 일반 중간지점 결과 타입을 반환한다")
-        void returnsNormalResultTypeWhenRecommendationDurationsDiffer() {
+        @DisplayName("출발지가 가까우면 추천 후보 간 평균 시간이 벌어져도 근거리 출발지 결과 타입을 반환한다")
+        void returnsNearbyDeparturesResultTypeWhenDeparturesAreCloseEvenIfRecommendationDurationsDiffer() {
+            mockMeetingWithLocationPoll();
+            LocationVote vote1 = createMockVote("37.5727", "127.0164", "참가자A", "동묘앞역");
+            LocationVote vote2 = createMockVote("37.5714", "127.0095", "참가자B", "동대문역");
+            when(locationVoteRepository.findByLocationPoll_Id(1L)).thenReturn(List.of(vote1, vote2));
+            when(stationRepository.calculateCentroid(any())).thenThrow(new RuntimeException("PostGIS 미지원"));
+            List<Station> stations = List.of(
+                    createMockStation(1L, "동묘앞역", "1호선", 37.5732, 127.0165),
+                    createMockStation(2L, "동대문역", "1호선", 37.5714, 127.0095),
+                    createMockStation(3L, "종로5가역", "1호선", 37.5709, 127.0019)
+            );
+            when(stationRepository.findNearbyStations(anyDouble(), anyDouble(), anyInt(), anyInt()))
+                    .thenReturn(stations);
+            when(googleRoutesClient.computeTransitMatrix(anyList(), anyList(), any()))
+                    .thenReturn(List.of(
+                            List.of(new TransitRouteResult(6, 500, true), new TransitRouteResult(8, 800, true),
+                                    new TransitRouteResult(18, 1600, true)),
+                            List.of(new TransitRouteResult(7, 600, true), new TransitRouteResult(5, 400, true),
+                                    new TransitRouteResult(20, 1800, true))
+                    ));
+            when(kakaoDirectionsClient.requestDrivingRoute(anyDouble(), anyDouble(), anyDouble(), anyDouble(), any()))
+                    .thenReturn(new KakaoDirectionsResponse.Summary(1500, 360, null));
+
+            MidpointRecommendationResponse response =
+                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null);
+
+            assertThat(response.resultType().name()).isEqualTo("NEARBY_DEPARTURES");
+        }
+
+        @Test
+        @DisplayName("출발지가 멀리 떨어져 있으면 일반 중간지점 결과 타입을 반환한다")
+        void returnsNormalResultTypeWhenDeparturesAreFarApart() {
             mockMeetingWithLocationPoll();
             LocationVote vote1 = createMockVote("37.5000", "127.0000", "참가자A", "서울시 강남구");
             LocationVote vote2 = createMockVote("37.6500", "126.7700", "참가자B", "경기 고양시");


### PR DESCRIPTION
## 변경 내용
- 근거리 결과 타입 판정을 후보역 평균 시간 차이 대신 출발지 간 거리 기준으로 보정
- 출발지들이 2km 이내이고 1순위 후보역까지 모두 15분 이내면 NEARBY_DEPARTURES 반환
- 근거리 출발지일 때는 추천역 정렬을 중심점 거리 우선으로 보정
- 출발지가 역 바로 근처이면 Google 대중교통 매트릭스가 누락되거나 시간이 과도하게 길어도 도보 경로로 보정
- 동묘앞/동대문, 홍대입구/홍대입구, 홍대입구 2호선/홍대입구 공항철도 회귀 케이스 추가

## 검증
- ./gradlew test --tests 'com.dnd.moyeolak.domain.location.service.MidpointRecommendationServiceImplTest'
- ./gradlew test --tests 'com.dnd.moyeolak.domain.location.service.MidpointRecommendationServiceImplTest.prefersNearestStationToCenterWhenDeparturesAreClose'
- ./gradlew test --tests 'com.dnd.moyeolak.domain.location.service.MidpointRecommendationServiceImplTest.treatsVeryCloseUnreachableTransitRoutesAsWalkable'
- ./gradlew test --tests 'com.dnd.moyeolak.domain.location.service.MidpointRecommendationServiceImplTest.shortensInflatedTransitRoutesWhenDepartureIsVeryCloseToStation'
- ./gradlew build