### PR TITLE
fix: 감사 시간 KST 저장 적용

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN ./gradlew clean build -x test --no-daemon
 FROM eclipse-temurin:25-jre
 
 WORKDIR /app
+ENV TZ=Asia/Seoul
 
 # 빌드된 JAR 파일 복사
 COPY --from=builder /app/build/libs/*.jar app.jar
@@ -31,4 +32,4 @@ COPY --from=builder /app/build/libs/*.jar app.jar
 EXPOSE 8080
 
 # 애플리케이션 실행
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "app.jar"]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -4,9 +4,10 @@
 FROM eclipse-temurin:25-jre
 
 WORKDIR /app
+ENV TZ=Asia/Seoul
 
 COPY build/libs/*.jar app.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       POSTGRES_USER: moyeolak
       POSTGRES_PASSWORD: moyeolak
       TZ: Asia/Seoul
+    command: ["postgres", "-c", "timezone=Asia/Seoul"]
     ports:
       - "5432:5432"
     volumes:

--- a/infra/deploy/docker-compose.prod.yml
+++ b/infra/deploy/docker-compose.prod.yml
@@ -32,8 +32,9 @@ services:
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}
       ODSAY_API_KEY: ${ODSAY_API_KEY}
       SWAGGER_SERVER_URL: ${SWAGGER_SERVER_URL}
+      TZ: Asia/Seoul
       # 2GB 인스턴스에서 힙 폭주 방지
-      JAVA_TOOL_OPTIONS: "-XX:MaxRAMPercentage=50.0"
+      JAVA_TOOL_OPTIONS: "-XX:MaxRAMPercentage=50.0 -Duser.timezone=Asia/Seoul"
     volumes:
       - ./logs:/logs
     depends_on:
@@ -53,6 +54,7 @@ services:
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       TZ: Asia/Seoul
+    command: ["postgres", "-c", "timezone=Asia/Seoul"]
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:

--- a/src/main/java/com/dnd/moyeolak/MoyeolakApplication.java
+++ b/src/main/java/com/dnd/moyeolak/MoyeolakApplication.java
@@ -2,9 +2,7 @@ package com.dnd.moyeolak;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class MoyeolakApplication {
 

--- a/src/main/java/com/dnd/moyeolak/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/dnd/moyeolak/global/config/JpaAuditingConfig.java
@@ -1,0 +1,22 @@
+package com.dnd.moyeolak.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
+@Configuration
+@EnableJpaAuditing(dateTimeProviderRef = "kstDateTimeProvider")
+public class JpaAuditingConfig {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    @Bean
+    public DateTimeProvider kstDateTimeProvider() {
+        return () -> Optional.of(LocalDateTime.now(KST));
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -8,6 +8,8 @@ spring:
     username: moyeolak
     password: moyeolak
     driver-class-name: org.postgresql.Driver
+    hikari:
+      connection-init-sql: SET TIME ZONE 'Asia/Seoul'
 
   jpa:
     show-sql: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -8,6 +8,8 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
+    hikari:
+      connection-init-sql: SET TIME ZONE 'Asia/Seoul'
 
   jpa:
     open-in-view: false

--- a/src/main/resources/db/migration/V3__convert_audit_timestamps_to_kst.sql
+++ b/src/main/resources/db/migration/V3__convert_audit_timestamps_to_kst.sql
@@ -1,0 +1,31 @@
+UPDATE meeting
+SET created_at = created_at + INTERVAL '9 hours',
+    updated_at = updated_at + INTERVAL '9 hours';
+
+UPDATE schedule_poll
+SET created_at = created_at + INTERVAL '9 hours',
+    updated_at = updated_at + INTERVAL '9 hours';
+
+UPDATE location_poll
+SET created_at = created_at + INTERVAL '9 hours',
+    updated_at = updated_at + INTERVAL '9 hours';
+
+UPDATE participant
+SET created_at = created_at + INTERVAL '9 hours',
+    updated_at = updated_at + INTERVAL '9 hours';
+
+UPDATE schedule_vote
+SET created_at = created_at + INTERVAL '9 hours',
+    updated_at = updated_at + INTERVAL '9 hours';
+
+UPDATE location_vote
+SET created_at = created_at + INTERVAL '9 hours',
+    updated_at = updated_at + INTERVAL '9 hours';
+
+UPDATE nearby_place
+SET created_at = created_at + INTERVAL '9 hours',
+    updated_at = updated_at + INTERVAL '9 hours';
+
+UPDATE nearby_place_hours
+SET created_at = created_at + INTERVAL '9 hours',
+    updated_at = updated_at + INTERVAL '9 hours';

--- a/src/test/java/com/dnd/moyeolak/global/config/JpaAuditingConfigTest.java
+++ b/src/test/java/com/dnd/moyeolak/global/config/JpaAuditingConfigTest.java
@@ -1,0 +1,73 @@
+package com.dnd.moyeolak.global.config;
+
+import com.dnd.moyeolak.domain.meeting.entity.Meeting;
+import com.dnd.moyeolak.domain.meeting.repository.MeetingRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.TimeZone;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class JpaAuditingConfigTest {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    @Autowired
+    @Qualifier("kstDateTimeProvider")
+    private DateTimeProvider dateTimeProvider;
+
+    @Autowired
+    private MeetingRepository meetingRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    void shouldProvideKoreanLocalDateTimeEvenWhenJvmDefaultTimezoneIsUtc() {
+        TimeZone originalTimeZone = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+
+        try {
+            LocalDateTime providedNow = LocalDateTime.from(dateTimeProvider.getNow().orElseThrow());
+            LocalDateTime kstNow = LocalDateTime.now(KST);
+
+            assertThat(Duration.between(providedNow, kstNow).abs()).isLessThan(Duration.ofSeconds(2));
+        } finally {
+            TimeZone.setDefault(originalTimeZone);
+        }
+    }
+
+    @Test
+    @Transactional
+    void shouldPersistAuditTimestampAsKoreanLocalDateTimeEvenWhenJvmDefaultTimezoneIsUtc() {
+        TimeZone originalTimeZone = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+
+        try {
+            Meeting meeting = Meeting.of(3);
+
+            Meeting saved = meetingRepository.save(meeting);
+            entityManager.flush();
+            entityManager.clear();
+
+            Meeting found = meetingRepository.findById(saved.getId()).orElseThrow();
+            LocalDateTime kstNow = LocalDateTime.now(KST);
+
+            assertThat(Duration.between(found.getCreatedAt(), kstNow).abs()).isLessThan(Duration.ofSeconds(2));
+        } finally {
+            TimeZone.setDefault(originalTimeZone);
+        }
+    }
+}

--- a/src/test/java/com/dnd/moyeolak/global/config/PostgisFlywayMigrationTest.java
+++ b/src/test/java/com/dnd/moyeolak/global/config/PostgisFlywayMigrationTest.java
@@ -50,9 +50,9 @@ class PostgisFlywayMigrationTest {
         Integer stationCount = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM stations", Integer.class);
         String postgisVersion = jdbcTemplate.queryForObject("SELECT PostGIS_Version()", String.class);
 
-        assertThat(appliedMigrationCount).isEqualTo(2);
+        assertThat(appliedMigrationCount).isEqualTo(3);
         assertThat(stationCount).isPositive();
         assertThat(postgisVersion).isNotBlank();
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("2");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("3");
     }
 }


### PR DESCRIPTION
## Summary
- JPA Auditing 시간을 Asia/Seoul 기준 LocalDateTime으로 생성하도록 DateTimeProvider를 추가
- 기존 감사 컬럼 데이터를 +9 hours 보정하는 Flyway V3 마이그레이션 추가
- 운영/로컬 Docker, JDBC 커넥션 타임존을 Asia/Seoul로 고정

## Root Cause
운영 backend 컨테이너와 JVM이 UTC로 실행되고 있었고, created_at/updated_at은 DB 기본값이 아니라 JPA Auditing의 LocalDateTime으로 생성되어 timestamp 컬럼에 그대로 저장되고 있었습니다.

## Validation
- ./gradlew clean test