### PR TITLE
feat(location): 중간지점 추천 재계산 제한 추가

### DIFF
--- a/src/main/java/com/dnd/moyeolak/domain/location/controller/LocationController.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/controller/LocationController.java
@@ -17,10 +17,12 @@ import com.dnd.moyeolak.domain.location.service.MidpointRecommendationService;
 import com.dnd.moyeolak.domain.location.service.PersonalRouteQueryService;
 import com.dnd.moyeolak.domain.location.service.NearbyPlaceSearchService;
 import com.dnd.moyeolak.domain.meeting.dto.UpdateLocationVoteRequest;
+import com.dnd.moyeolak.global.ratelimit.ClientIpResolver;
 import com.dnd.moyeolak.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -41,6 +43,7 @@ public class LocationController {
     private final MidpointRecommendationService midpointRecommendationService;
     private final PersonalRouteQueryService personalRouteQueryService;
     private final NearbyPlaceSearchService nearbyPlaceSearchService;
+    private final ClientIpResolver clientIpResolver;
 
     @GetMapping("/midpoint-recommendations")
     @GetMidpointRecommendationsApiDocs
@@ -48,10 +51,12 @@ public class LocationController {
             @Parameter(description = "모임 ID", example = "test-meeting-001", required = true)
             @RequestParam String meetingId,
             @Parameter(description = "출발 시간 (미입력 시 현재 시각 기준)", example = "2026-02-18T10:30:00")
-            @RequestParam(required = false) LocalDateTime departureTime
+            @RequestParam(required = false) LocalDateTime departureTime,
+            HttpServletRequest request
     ) {
+        String clientIp = clientIpResolver.resolve(request);
         MidpointRecommendationResponse response =
-                midpointRecommendationService.calculateMidpointRecommendations(meetingId, departureTime);
+                midpointRecommendationService.calculateMidpointRecommendations(meetingId, departureTime, clientIp);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/dnd/moyeolak/domain/location/service/MidpointRecommendationService.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/service/MidpointRecommendationService.java
@@ -6,5 +6,9 @@ import java.time.LocalDateTime;
 
 public interface MidpointRecommendationService {
 
-    MidpointRecommendationResponse calculateMidpointRecommendations(String meetingId, LocalDateTime departureTime);
+    MidpointRecommendationResponse calculateMidpointRecommendations(
+            String meetingId,
+            LocalDateTime departureTime,
+            String clientIp
+    );
 }

--- a/src/main/java/com/dnd/moyeolak/domain/location/service/impl/MidpointRecommendationServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/service/impl/MidpointRecommendationServiceImpl.java
@@ -12,6 +12,7 @@ import com.dnd.moyeolak.global.client.google.dto.LatLng;
 import com.dnd.moyeolak.global.client.kakao.KakaoDirectionsClient;
 import com.dnd.moyeolak.global.client.kakao.dto.KakaoDirectionsResponse;
 import com.dnd.moyeolak.global.exception.BusinessException;
+import com.dnd.moyeolak.global.ratelimit.MidpointRecommendationUsageLimiter;
 import com.dnd.moyeolak.global.response.ErrorCode;
 import com.dnd.moyeolak.global.station.entity.Station;
 import com.dnd.moyeolak.global.station.repository.StationRepository;
@@ -41,6 +42,7 @@ public class MidpointRecommendationServiceImpl implements MidpointRecommendation
     private final StationRepository stationRepository;
     private final GoogleRoutesClient googleRoutesClient;
     private final KakaoDirectionsClient kakaoDirectionsClient;
+    private final MidpointRecommendationUsageLimiter usageLimiter;
 
     private static final int SEARCH_RADIUS_METERS = 5000;
     private static final int MAX_CANDIDATE_STATIONS = 10;
@@ -50,7 +52,11 @@ public class MidpointRecommendationServiceImpl implements MidpointRecommendation
 
     @Override
     @Cacheable(value = "midpointRecommendations", key = "#meetingId + '_' + #departureTime")
-    public MidpointRecommendationResponse calculateMidpointRecommendations(String meetingId, LocalDateTime departureTime) {
+    public MidpointRecommendationResponse calculateMidpointRecommendations(
+            String meetingId,
+            LocalDateTime departureTime,
+            String clientIp
+    ) {
         // 1. 출발지 데이터 조회
         Meeting meeting = meetingService.get(meetingId);
         LocationPoll locationPoll = meeting.getLocationPoll();
@@ -81,6 +87,8 @@ public class MidpointRecommendationServiceImpl implements MidpointRecommendation
             throw new BusinessException(ErrorCode.NO_NEARBY_STATIONS);
         }
         log.info("후보 지하철역 {}개 검색 완료", candidateStations.size());
+
+        usageLimiter.checkAndIncrease(meetingId, clientIp);
 
         // 4. Google 매트릭스 1회로 전 후보역의 대중교통 시간 계산
         List<List<TransitRouteResult>> transitMatrix = googleRoutesClient.computeTransitMatrix(

--- a/src/main/java/com/dnd/moyeolak/global/ratelimit/ClientIpResolver.java
+++ b/src/main/java/com/dnd/moyeolak/global/ratelimit/ClientIpResolver.java
@@ -1,0 +1,26 @@
+package com.dnd.moyeolak.global.ratelimit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ClientIpResolver {
+
+    public String resolve(HttpServletRequest request) {
+        String forwardedFor = request.getHeader("X-Forwarded-For");
+        if (forwardedFor != null && !forwardedFor.isBlank()) {
+            return forwardedFor.split(",", 2)[0].trim();
+        }
+
+        String realIp = request.getHeader("X-Real-IP");
+        if (realIp != null && !realIp.isBlank()) {
+            return realIp.trim();
+        }
+
+        String remoteAddr = request.getRemoteAddr();
+        if (remoteAddr == null || remoteAddr.isBlank()) {
+            return "unknown";
+        }
+        return remoteAddr.trim();
+    }
+}

--- a/src/main/java/com/dnd/moyeolak/global/ratelimit/InMemoryRateLimitCounter.java
+++ b/src/main/java/com/dnd/moyeolak/global/ratelimit/InMemoryRateLimitCounter.java
@@ -1,0 +1,36 @@
+package com.dnd.moyeolak.global.ratelimit;
+
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Component
+public class InMemoryRateLimitCounter implements RateLimitCounter {
+
+    private final ConcurrentMap<String, CounterState> counters = new ConcurrentHashMap<>();
+    private final Clock clock;
+
+    public InMemoryRateLimitCounter(Clock clock) {
+        this.clock = clock;
+    }
+
+    @Override
+    public long increaseAndGet(String key, Instant expiresAt) {
+        Instant now = clock.instant();
+        CounterState state = counters.compute(key, (ignored, existing) -> {
+            if (existing == null || !existing.expiresAt().isAfter(now)) {
+                return new CounterState(new AtomicLong(1), expiresAt);
+            }
+            existing.count().incrementAndGet();
+            return existing;
+        });
+        return state.count().get();
+    }
+
+    private record CounterState(AtomicLong count, Instant expiresAt) {
+    }
+}

--- a/src/main/java/com/dnd/moyeolak/global/ratelimit/MidpointRecommendationUsageLimiter.java
+++ b/src/main/java/com/dnd/moyeolak/global/ratelimit/MidpointRecommendationUsageLimiter.java
@@ -1,0 +1,82 @@
+package com.dnd.moyeolak.global.ratelimit;
+
+import com.dnd.moyeolak.global.exception.BusinessException;
+import com.dnd.moyeolak.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class MidpointRecommendationUsageLimiter {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter DAILY_KEY_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final DateTimeFormatter MINUTE_KEY_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
+
+    private final RateLimitProperties properties;
+    private final RateLimitCounter counter;
+    private final Clock clock;
+
+    public void checkAndIncrease(String meetingId, String clientIp) {
+        if (!properties.isEnabled()) {
+            return;
+        }
+
+        ZonedDateTime now = ZonedDateTime.now(clock).withZoneSameInstant(KST);
+        String safeClientIp = normalizeClientIp(clientIp);
+        List<RateLimitRule> rules = List.of(
+                new RateLimitRule(
+                        "midpoint:meeting:daily:%s:%s".formatted(dailyKey(now), meetingId),
+                        nextMidnight(now),
+                        properties.getMeetingDailyLimit()
+                ),
+                new RateLimitRule(
+                        "midpoint:ip:minute:%s:%s".formatted(minuteKey(now), safeClientIp),
+                        now.truncatedTo(ChronoUnit.MINUTES).plusMinutes(2).toInstant(),
+                        properties.getIpMinuteLimit()
+                ),
+                new RateLimitRule(
+                        "midpoint:ip:daily:%s:%s".formatted(dailyKey(now), safeClientIp),
+                        nextMidnight(now),
+                        properties.getIpDailyLimit()
+                )
+        );
+
+        for (RateLimitRule rule : rules) {
+            long count = counter.increaseAndGet(rule.key(), rule.expiresAt());
+            if (count > rule.limit()) {
+                throw new BusinessException(ErrorCode.MIDPOINT_RECOMMENDATION_RATE_LIMIT_EXCEEDED);
+            }
+        }
+    }
+
+    private String normalizeClientIp(String clientIp) {
+        if (clientIp == null || clientIp.isBlank()) {
+            return "unknown";
+        }
+        return clientIp.trim();
+    }
+
+    private String dailyKey(ZonedDateTime now) {
+        return now.format(DAILY_KEY_FORMATTER);
+    }
+
+    private String minuteKey(ZonedDateTime now) {
+        return now.format(MINUTE_KEY_FORMATTER);
+    }
+
+    private Instant nextMidnight(ZonedDateTime now) {
+        return now.toLocalDate().plusDays(1).atStartOfDay(KST).toInstant();
+    }
+
+    private record RateLimitRule(String key, Instant expiresAt, int limit) {
+    }
+}

--- a/src/main/java/com/dnd/moyeolak/global/ratelimit/RateLimitCounter.java
+++ b/src/main/java/com/dnd/moyeolak/global/ratelimit/RateLimitCounter.java
@@ -1,0 +1,8 @@
+package com.dnd.moyeolak.global.ratelimit;
+
+import java.time.Instant;
+
+public interface RateLimitCounter {
+
+    long increaseAndGet(String key, Instant expiresAt);
+}

--- a/src/main/java/com/dnd/moyeolak/global/ratelimit/RateLimitProperties.java
+++ b/src/main/java/com/dnd/moyeolak/global/ratelimit/RateLimitProperties.java
@@ -1,0 +1,18 @@
+package com.dnd.moyeolak.global.ratelimit;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "moyeolak.rate-limit.midpoint-recommendation")
+public class RateLimitProperties {
+
+    private boolean enabled = true;
+    private int meetingDailyLimit = 20;
+    private int ipMinuteLimit = 5;
+    private int ipDailyLimit = 100;
+}

--- a/src/main/java/com/dnd/moyeolak/global/response/ErrorCode.java
+++ b/src/main/java/com/dnd/moyeolak/global/response/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     KAKAO_API_ERROR("E424", "자동차 경로 조회에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     INSUFFICIENT_LOCATION_VOTES("E425", "출발지 2개 이상 등록 시 중간지점을 확인할 수 있습니다.", HttpStatus.BAD_REQUEST),
     INVALID_TIME_RANGE("E426", "시작 시간은 종료 시간보다 빨라야 합니다.", HttpStatus.BAD_REQUEST),
+    MIDPOINT_RECOMMENDATION_RATE_LIMIT_EXCEEDED("E427", "중간지점 추천 재계산 요청 한도를 초과했습니다. 잠시 후 다시 시도해주세요.", HttpStatus.TOO_MANY_REQUESTS),
 
     // 서버 오류
     SERVER_ERROR("E500", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,3 +6,11 @@ spring:
   threads:
     virtual:
       enabled: true
+
+moyeolak:
+  rate-limit:
+    midpoint-recommendation:
+      enabled: true
+      meeting-daily-limit: 20
+      ip-minute-limit: 5
+      ip-daily-limit: 100

--- a/src/test/java/com/dnd/moyeolak/domain/location/controller/LocationControllerTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/location/controller/LocationControllerTest.java
@@ -1,0 +1,88 @@
+package com.dnd.moyeolak.domain.location.controller;
+
+import com.dnd.moyeolak.domain.location.dto.CenterPointDto;
+import com.dnd.moyeolak.domain.location.dto.MidpointRecommendationResponse;
+import com.dnd.moyeolak.domain.location.service.LocationVoteService;
+import com.dnd.moyeolak.domain.location.service.MidpointRecommendationService;
+import com.dnd.moyeolak.domain.location.service.NearbyPlaceSearchService;
+import com.dnd.moyeolak.domain.location.service.PersonalRouteQueryService;
+import com.dnd.moyeolak.global.exception.GlobalExceptionAdvice;
+import com.dnd.moyeolak.global.ratelimit.ClientIpResolver;
+import com.dnd.moyeolak.global.response.SuccessCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class LocationControllerTest {
+
+    private static final String MEETING_ID = "meeting-123";
+
+    @Mock
+    private LocationVoteService locationVoteService;
+
+    @Mock
+    private MidpointRecommendationService midpointRecommendationService;
+
+    @Mock
+    private PersonalRouteQueryService personalRouteQueryService;
+
+    @Mock
+    private NearbyPlaceSearchService nearbyPlaceSearchService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        LocationController controller = new LocationController(
+                locationVoteService,
+                midpointRecommendationService,
+                personalRouteQueryService,
+                nearbyPlaceSearchService,
+                new ClientIpResolver()
+        );
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionAdvice())
+                .build();
+    }
+
+    @Test
+    @DisplayName("중간지점 추천 API는 X-Forwarded-For 첫 번째 IP를 서비스에 전달한다")
+    void getMidpointRecommendations_passesResolvedClientIp() throws Exception {
+        MidpointRecommendationResponse response = new MidpointRecommendationResponse(
+                new CenterPointDto(37.5, 127.0),
+                List.of(),
+                null,
+                2,
+                5
+        );
+        when(midpointRecommendationService.calculateMidpointRecommendations(
+                eq(MEETING_ID), eq(null), eq("203.0.113.10")))
+                .thenReturn(response);
+
+        mockMvc.perform(get("/api/locations/midpoint-recommendations")
+                        .param("meetingId", MEETING_ID)
+                        .header("X-Forwarded-For", "203.0.113.10, 10.0.0.1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(SuccessCode.OK.getCode()))
+                .andExpect(jsonPath("$.data.registeredCount").value(2))
+                .andExpect(jsonPath("$.data.totalCount").value(5));
+
+        verify(midpointRecommendationService)
+                .calculateMidpointRecommendations(MEETING_ID, null, "203.0.113.10");
+    }
+}

--- a/src/test/java/com/dnd/moyeolak/domain/location/service/MidpointRecommendationServiceImplTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/location/service/MidpointRecommendationServiceImplTest.java
@@ -15,6 +15,7 @@ import com.dnd.moyeolak.global.client.google.GoogleRoutesClient;
 import com.dnd.moyeolak.global.client.kakao.KakaoDirectionsClient;
 import com.dnd.moyeolak.global.client.kakao.dto.KakaoDirectionsResponse;
 import com.dnd.moyeolak.global.exception.BusinessException;
+import com.dnd.moyeolak.global.ratelimit.MidpointRecommendationUsageLimiter;
 import com.dnd.moyeolak.global.response.ErrorCode;
 import com.dnd.moyeolak.global.station.entity.Station;
 import com.dnd.moyeolak.global.station.repository.StationRepository;
@@ -39,9 +40,12 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.ArgumentMatchers.eq;
 
 @ExtendWith(MockitoExtension.class)
 class MidpointRecommendationServiceImplTest {
@@ -61,6 +65,9 @@ class MidpointRecommendationServiceImplTest {
     @Mock
     private KakaoDirectionsClient kakaoDirectionsClient;
 
+    @Mock
+    private MidpointRecommendationUsageLimiter usageLimiter;
+
     @InjectMocks
     private MidpointRecommendationServiceImpl midpointRecommendationService;
 
@@ -77,7 +84,7 @@ class MidpointRecommendationServiceImplTest {
             when(meetingService.get(MEETING_ID)).thenReturn(meeting);
             when(meeting.getLocationPoll()).thenReturn(null);
 
-            assertThatThrownBy(() -> midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null))
+            assertThatThrownBy(() -> midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null, "unknown"))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.LOCATION_POLL_NOT_FOUND);
         }
@@ -93,7 +100,7 @@ class MidpointRecommendationServiceImplTest {
             when(locationPoll.getId()).thenReturn(1L);
             when(locationVoteRepository.findByLocationPoll_Id(1L)).thenReturn(Collections.emptyList());
 
-            assertThatThrownBy(() -> midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null))
+            assertThatThrownBy(() -> midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null, "unknown"))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INSUFFICIENT_LOCATION_VOTES)
                     .satisfies(ex -> {
@@ -114,7 +121,7 @@ class MidpointRecommendationServiceImplTest {
             when(stationRepository.findNearbyStations(anyDouble(), anyDouble(), anyInt(), anyInt()))
                     .thenReturn(Collections.emptyList());
 
-            assertThatThrownBy(() -> midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null))
+            assertThatThrownBy(() -> midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null, "unknown"))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NO_NEARBY_STATIONS);
         }
@@ -136,9 +143,36 @@ class MidpointRecommendationServiceImplTest {
                             List.of(TransitRouteResult.unreachable())
                     ));
 
-            assertThatThrownBy(() -> midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null))
+            assertThatThrownBy(() -> midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null, "unknown"))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GOOGLE_API_ERROR);
+        }
+
+        @Test
+        @DisplayName("재계산 제한을 초과하면 외부 API를 호출하지 않고 429 예외가 발생한다")
+        void throwsRateLimitExceededBeforeCallingExternalApis() {
+            mockMeetingWithLocationPoll();
+            LocationVote vote1 = createMockVote("37.5000", "127.0000", "참가자A", "서울시 강남구");
+            LocationVote vote2 = createMockVote("37.5100", "127.0100", "참가자B", "서울시 강동구");
+            when(locationVoteRepository.findByLocationPoll_Id(1L)).thenReturn(List.of(vote1, vote2));
+            when(stationRepository.calculateCentroid(any())).thenThrow(new RuntimeException("PostGIS 미지원"));
+            Station station = createMockStation(1L, "강남역", "2호선", 37.4979, 127.0276);
+            when(stationRepository.findNearbyStations(anyDouble(), anyDouble(), anyInt(), anyInt()))
+                    .thenReturn(List.of(station));
+            doThrow(new BusinessException(ErrorCode.MIDPOINT_RECOMMENDATION_RATE_LIMIT_EXCEEDED))
+                    .when(usageLimiter).checkAndIncrease(eq(MEETING_ID), eq("203.0.113.10"));
+
+            assertThatThrownBy(() -> midpointRecommendationService.calculateMidpointRecommendations(
+                    MEETING_ID, null, "203.0.113.10"))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue(
+                            "errorCode",
+                            ErrorCode.MIDPOINT_RECOMMENDATION_RATE_LIMIT_EXCEEDED
+                    );
+
+            verify(googleRoutesClient, never()).computeTransitMatrix(anyList(), anyList(), any());
+            verify(kakaoDirectionsClient, never())
+                    .requestDrivingRoute(anyDouble(), anyDouble(), anyDouble(), anyDouble(), any());
         }
     }
 
@@ -171,7 +205,7 @@ class MidpointRecommendationServiceImplTest {
                     .thenReturn(new KakaoDirectionsResponse.Summary(12000, 1800, null));
 
             MidpointRecommendationResponse response =
-                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null);
+                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null, "unknown");
 
             assertThat(response.centerPoint().latitude()).isEqualTo(37.525);
             assertThat(response.centerPoint().longitude()).isEqualTo(126.975);
@@ -219,7 +253,7 @@ class MidpointRecommendationServiceImplTest {
                     .thenReturn(new KakaoDirectionsResponse.Summary(5000, 600, null));
 
             MidpointRecommendationResponse response =
-                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null);
+                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null, "unknown");
 
             assertThat(response.recommendations()).hasSize(3);
             assertThat(response.recommendations()).extracting("stationName")
@@ -250,7 +284,7 @@ class MidpointRecommendationServiceImplTest {
                     .thenReturn(null);
 
             MidpointRecommendationResponse response =
-                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null);
+                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null, "unknown");
 
             assertThat(response.recommendations()).hasSize(1);
             assertThat(response.recommendations().getFirst().routes())
@@ -284,7 +318,7 @@ class MidpointRecommendationServiceImplTest {
                     .thenReturn(new KakaoDirectionsResponse.Summary(5000, 600, null));
 
             MidpointRecommendationResponse response =
-                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null);
+                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null, "unknown");
 
             assertThat(response.recommendations().getFirst().routes().getFirst().departureName())
                     .isEqualTo("김참가자");

--- a/src/test/java/com/dnd/moyeolak/global/client/google/GoogleRoutesClientTest.java
+++ b/src/test/java/com/dnd/moyeolak/global/client/google/GoogleRoutesClientTest.java
@@ -124,7 +124,7 @@ class GoogleRoutesClientTest {
     @DisplayName("departureTime을 KST 기준 RFC3339 UTC로 변환해 전송하고 소수점 초 duration도 파싱한다")
     void sendsDepartureTimeAsRfc3339AndParsesFractionalSeconds() {
         server.expect(requestTo(MATRIX_URL))
-                .andExpect(jsonPath("$.departureTime").value("2026-07-20T00:30:00Z"))
+                .andExpect(jsonPath("$.departureTime").value("2099-07-20T00:30:00Z"))
                 .andRespond(withSuccess("""
                         [{"originIndex":0,"destinationIndex":0,"condition":"ROUTE_EXISTS","distanceMeters":5000,"duration":"1234.5s"}]
                         """, MediaType.APPLICATION_JSON));
@@ -132,7 +132,7 @@ class GoogleRoutesClientTest {
         List<List<TransitRouteResult>> matrix = client.computeTransitMatrix(
                 List.of(new LatLng(37.5, 127.0)),
                 List.of(new LatLng(37.4979, 127.0276)),
-                java.time.LocalDateTime.of(2026, 7, 20, 9, 30)); // KST 09:30 -> UTC 00:30
+                java.time.LocalDateTime.of(2099, 7, 20, 9, 30)); // KST 09:30 -> UTC 00:30
 
         assertThat(matrix.get(0).get(0).durationMinutes()).isEqualTo(21); // 1234.5s -> 1234s -> 21분
         server.verify();

--- a/src/test/java/com/dnd/moyeolak/global/ratelimit/ClientIpResolverTest.java
+++ b/src/test/java/com/dnd/moyeolak/global/ratelimit/ClientIpResolverTest.java
@@ -1,0 +1,48 @@
+package com.dnd.moyeolak.global.ratelimit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ClientIpResolverTest {
+
+    private final ClientIpResolver resolver = new ClientIpResolver();
+
+    @Test
+    @DisplayName("X-Forwarded-For가 있으면 첫 번째 IP를 반환한다")
+    void resolve_usesFirstForwardedForIp() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeader("X-Forwarded-For")).thenReturn("203.0.113.10, 10.0.0.1");
+
+        String clientIp = resolver.resolve(request);
+
+        assertThat(clientIp).isEqualTo("203.0.113.10");
+    }
+
+    @Test
+    @DisplayName("X-Forwarded-For가 비어 있으면 X-Real-IP를 반환한다")
+    void resolve_fallsBackToRealIp() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeader("X-Forwarded-For")).thenReturn(" ");
+        when(request.getHeader("X-Real-IP")).thenReturn("198.51.100.20");
+
+        String clientIp = resolver.resolve(request);
+
+        assertThat(clientIp).isEqualTo("198.51.100.20");
+    }
+
+    @Test
+    @DisplayName("프록시 헤더가 없으면 remoteAddr를 반환한다")
+    void resolve_fallsBackToRemoteAddr() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+
+        String clientIp = resolver.resolve(request);
+
+        assertThat(clientIp).isEqualTo("127.0.0.1");
+    }
+}

--- a/src/test/java/com/dnd/moyeolak/global/ratelimit/InMemoryRateLimitCounterTest.java
+++ b/src/test/java/com/dnd/moyeolak/global/ratelimit/InMemoryRateLimitCounterTest.java
@@ -1,0 +1,75 @@
+package com.dnd.moyeolak.global.ratelimit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InMemoryRateLimitCounterTest {
+
+    @Test
+    @DisplayName("같은 윈도우의 key 카운트를 증가시킨다")
+    void increaseAndGet_incrementsSameKeyCount() {
+        InMemoryRateLimitCounter counter = new InMemoryRateLimitCounter(fixedClock("2026-07-22T00:00:00Z"));
+        Instant expiresAt = Instant.parse("2026-07-23T00:00:00Z");
+
+        long first = counter.increaseAndGet("midpoint:meeting:daily:20260722:meeting-1", expiresAt);
+        long second = counter.increaseAndGet("midpoint:meeting:daily:20260722:meeting-1", expiresAt);
+
+        assertThat(first).isEqualTo(1);
+        assertThat(second).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("만료된 key는 새 카운터로 다시 시작한다")
+    void increaseAndGet_resetsExpiredKey() {
+        MutableClock clock = new MutableClock(Instant.parse("2026-07-22T00:00:00Z"));
+        InMemoryRateLimitCounter counter = new InMemoryRateLimitCounter(clock);
+
+        counter.increaseAndGet("midpoint:ip:minute:202607220900:203.0.113.10",
+                Instant.parse("2026-07-22T00:01:00Z"));
+        clock.advance(Duration.ofMinutes(2));
+
+        long count = counter.increaseAndGet("midpoint:ip:minute:202607220900:203.0.113.10",
+                Instant.parse("2026-07-22T00:03:00Z"));
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    private Clock fixedClock(String instant) {
+        return Clock.fixed(Instant.parse(instant), ZoneId.of("UTC"));
+    }
+
+    private static class MutableClock extends Clock {
+
+        private Instant instant;
+
+        private MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        private void advance(Duration duration) {
+            this.instant = this.instant.plus(duration);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneId.of("UTC");
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+    }
+}

--- a/src/test/java/com/dnd/moyeolak/global/ratelimit/MidpointRecommendationUsageLimiterTest.java
+++ b/src/test/java/com/dnd/moyeolak/global/ratelimit/MidpointRecommendationUsageLimiterTest.java
@@ -1,0 +1,82 @@
+package com.dnd.moyeolak.global.ratelimit;
+
+import com.dnd.moyeolak.global.exception.BusinessException;
+import com.dnd.moyeolak.global.response.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MidpointRecommendationUsageLimiterTest {
+
+    private RateLimitProperties properties;
+    private MidpointRecommendationUsageLimiter limiter;
+
+    @BeforeEach
+    void setUp() {
+        properties = new RateLimitProperties();
+        properties.setMeetingDailyLimit(2);
+        properties.setIpMinuteLimit(2);
+        properties.setIpDailyLimit(3);
+
+        Clock clock = Clock.fixed(Instant.parse("2026-07-22T03:00:00Z"), ZoneId.of("UTC"));
+        limiter = new MidpointRecommendationUsageLimiter(
+                properties,
+                new InMemoryRateLimitCounter(clock),
+                clock
+        );
+    }
+
+    @Test
+    @DisplayName("meeting 일별 제한을 초과하면 429 예외가 발생한다")
+    void checkAndIncrease_blocksWhenMeetingDailyLimitExceeded() {
+        limiter.checkAndIncrease("meeting-1", "203.0.113.10");
+        limiter.checkAndIncrease("meeting-1", "203.0.113.11");
+
+        assertThatThrownBy(() -> limiter.checkAndIncrease("meeting-1", "203.0.113.12"))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode",
+                        ErrorCode.MIDPOINT_RECOMMENDATION_RATE_LIMIT_EXCEEDED);
+    }
+
+    @Test
+    @DisplayName("IP 분당 제한을 초과하면 429 예외가 발생한다")
+    void checkAndIncrease_blocksWhenIpMinuteLimitExceeded() {
+        limiter.checkAndIncrease("meeting-1", "203.0.113.10");
+        limiter.checkAndIncrease("meeting-2", "203.0.113.10");
+
+        assertThatThrownBy(() -> limiter.checkAndIncrease("meeting-3", "203.0.113.10"))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode",
+                        ErrorCode.MIDPOINT_RECOMMENDATION_RATE_LIMIT_EXCEEDED);
+    }
+
+    @Test
+    @DisplayName("IP 일별 제한을 초과하면 429 예외가 발생한다")
+    void checkAndIncrease_blocksWhenIpDailyLimitExceeded() {
+        properties.setIpMinuteLimit(10);
+        limiter.checkAndIncrease("meeting-1", "203.0.113.10");
+        limiter.checkAndIncrease("meeting-2", "203.0.113.10");
+        limiter.checkAndIncrease("meeting-3", "203.0.113.10");
+
+        assertThatThrownBy(() -> limiter.checkAndIncrease("meeting-4", "203.0.113.10"))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode",
+                        ErrorCode.MIDPOINT_RECOMMENDATION_RATE_LIMIT_EXCEEDED);
+    }
+
+    @Test
+    @DisplayName("비활성화 상태이면 제한을 적용하지 않는다")
+    void checkAndIncrease_allowsWhenDisabled() {
+        properties.setEnabled(false);
+
+        limiter.checkAndIncrease("meeting-1", "203.0.113.10");
+        limiter.checkAndIncrease("meeting-1", "203.0.113.10");
+        limiter.checkAndIncrease("meeting-1", "203.0.113.10");
+    }
+}


### PR DESCRIPTION
## Summary
- 중간지점 추천 cache miss 재계산 요청에 인메모리 rate limit 적용
- meeting 일별, client IP 분당/일별 제한 추가
- 제한 초과 시 HTTP 429 응답을 위한 ErrorCode 추가
- 프록시 헤더 기반 client IP 전달 및 관련 테스트 추가
- GoogleRoutesClientTest의 과거 고정 날짜를 미래 날짜로 보정해 시간 의존 실패 제거

## Validation
- ./gradlew test --tests 'com.dnd.moyeolak.global.ratelimit.*' --tests 'com.dnd.moyeolak.domain.location.controller.LocationControllerTest' --tests 'com.dnd.moyeolak.domain.location.service.MidpointRecommendationServiceImplTest'
- ./gradlew build

Closes #150