### PR TITLE
fix(location): 중간지점 추천 CI 오류 수정

### DIFF
--- a/src/main/java/com/dnd/moyeolak/global/response/ErrorCode.java
+++ b/src/main/java/com/dnd/moyeolak/global/response/ErrorCode.java
@@ -35,11 +35,11 @@ public enum ErrorCode {
     KAKAO_API_ERROR("E424", "자동차 경로 조회에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     INSUFFICIENT_LOCATION_VOTES("E425", "출발지 2개 이상 등록 시 중간지점을 확인할 수 있습니다.", HttpStatus.BAD_REQUEST),
     INVALID_TIME_RANGE("E426", "시작 시간은 종료 시간보다 빨라야 합니다.", HttpStatus.BAD_REQUEST),
-    MIDPOINT_RECOMMENDATION_RATE_LIMIT_EXCEEDED("E427", "중간지점 추천 재계산 요청 한도를 초과했습니다. 잠시 후 다시 시도해주세요.", HttpStatus.TOO_MANY_REQUESTS),
     OUT_OF_SERVICE_AREA("E427", "서비스 지역(수도권) 밖의 출발지는 등록할 수 없습니다.", HttpStatus.BAD_REQUEST),
     ROUTE_NOT_FOUND("E428", "출발지에서 도착역까지 이동 경로를 찾을 수 없습니다.", HttpStatus.UNPROCESSABLE_ENTITY),
     NO_REACHABLE_STATIONS("E429", "출발지에서 대중교통으로 도달 가능한 후보 역이 없습니다.", HttpStatus.UNPROCESSABLE_ENTITY),
     DUPLICATE_LOCATION_VOTE("E430", "이미 출발지를 등록한 참여자입니다.", HttpStatus.CONFLICT),
+    MIDPOINT_RECOMMENDATION_RATE_LIMIT_EXCEEDED("E431", "중간지점 추천 재계산 요청 한도를 초과했습니다. 잠시 후 다시 시도해주세요.", HttpStatus.TOO_MANY_REQUESTS),
 
     // 서버 오류
     SERVER_ERROR("E500", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/test/java/com/dnd/moyeolak/domain/location/controller/LocationControllerTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/location/controller/LocationControllerTest.java
@@ -2,6 +2,7 @@ package com.dnd.moyeolak.domain.location.controller;
 
 import com.dnd.moyeolak.domain.location.dto.CenterPointDto;
 import com.dnd.moyeolak.domain.location.dto.MidpointRecommendationResponse;
+import com.dnd.moyeolak.domain.location.enums.MidpointResultType;
 import com.dnd.moyeolak.domain.location.service.LocationVoteService;
 import com.dnd.moyeolak.domain.location.service.MidpointRecommendationService;
 import com.dnd.moyeolak.domain.location.service.NearbyPlaceSearchService;
@@ -68,7 +69,8 @@ class LocationControllerTest {
                 List.of(),
                 null,
                 2,
-                5
+                5,
+                MidpointResultType.NORMAL
         );
         when(midpointRecommendationService.calculateMidpointRecommendations(
                 eq(MEETING_ID), eq(null), eq("203.0.113.10")))

--- a/src/test/java/com/dnd/moyeolak/domain/location/service/MidpointRecommendationServiceImplTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/location/service/MidpointRecommendationServiceImplTest.java
@@ -314,7 +314,7 @@ class MidpointRecommendationServiceImplTest {
                     .thenReturn(new KakaoDirectionsResponse.Summary(5000, 600, null));
 
             MidpointRecommendationResponse response =
-                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null);
+                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null, "unknown");
 
             assertThat(response.recommendations()).extracting("stationName")
                     .containsExactly("역2", "역1");
@@ -343,7 +343,7 @@ class MidpointRecommendationServiceImplTest {
                     .thenReturn(null);
 
             MidpointRecommendationResponse response =
-                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null);
+                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null, "unknown");
 
             assertThat(response.recommendations().getFirst().routes())
                     .extracting("transitReachable").containsExactly(true, false);
@@ -377,7 +377,7 @@ class MidpointRecommendationServiceImplTest {
                     .thenReturn(new KakaoDirectionsResponse.Summary(2500, 480, null));
 
             MidpointRecommendationResponse response =
-                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null);
+                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null, "unknown");
 
             assertThat(response.resultType().name()).isEqualTo("NEARBY_DEPARTURES");
         }
@@ -408,7 +408,7 @@ class MidpointRecommendationServiceImplTest {
                     .thenReturn(new KakaoDirectionsResponse.Summary(1500, 360, null));
 
             MidpointRecommendationResponse response =
-                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null);
+                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null, "unknown");
 
             assertThat(response.resultType().name()).isEqualTo("NEARBY_DEPARTURES");
         }
@@ -439,7 +439,7 @@ class MidpointRecommendationServiceImplTest {
                     .thenReturn(new KakaoDirectionsResponse.Summary(1200, 300, null));
 
             MidpointRecommendationResponse response =
-                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null);
+                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null, "unknown");
 
             assertThat(response.recommendations()).extracting("stationName")
                     .containsExactly("홍대입구역", "신촌역", "합정역");
@@ -472,7 +472,7 @@ class MidpointRecommendationServiceImplTest {
                     .thenReturn(new KakaoDirectionsResponse.Summary(1200, 300, null));
 
             MidpointRecommendationResponse response =
-                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null);
+                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null, "unknown");
 
             StationRecommendationDto first = response.recommendations().getFirst();
             assertThat(first.stationName()).isEqualTo("홍대입구역");
@@ -506,7 +506,7 @@ class MidpointRecommendationServiceImplTest {
                     .thenReturn(new KakaoDirectionsResponse.Summary(1200, 300, null));
 
             MidpointRecommendationResponse response =
-                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null);
+                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null, "unknown");
 
             StationRecommendationDto first = response.recommendations().getFirst();
             assertThat(first.stationName()).isEqualTo("홍대입구역");
@@ -541,7 +541,7 @@ class MidpointRecommendationServiceImplTest {
                     .thenReturn(new KakaoDirectionsResponse.Summary(12000, 1800, null));
 
             MidpointRecommendationResponse response =
-                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null);
+                    midpointRecommendationService.calculateMidpointRecommendations(MEETING_ID, null, "unknown");
 
             assertThat(response.resultType().name()).isEqualTo("NORMAL");
         }


### PR DESCRIPTION
## Summary
- 최신 dev에 추가된 MidpointRecommendationServiceImplTest 호출부를 clientIp 포함 시그니처로 수정
- MidpointRecommendationResponse 테스트 생성자에 resultType 인자 추가
- 기존 ErrorCode E427 충돌을 피하도록 rate limit 에러 코드를 E431로 조정

## Validation
- ./gradlew test jacocoTestReport