### PR TITLE
내 모임 다시가기 API 추가

### DIFF
--- a/src/main/java/com/dnd/moyeolak/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/dnd/moyeolak/domain/meeting/controller/MeetingController.java
@@ -4,6 +4,7 @@ import com.dnd.moyeolak.domain.meeting.dto.CreateMeetingRequest;
 import com.dnd.moyeolak.domain.meeting.dto.GetMeetingScheduleResponse;
 import com.dnd.moyeolak.domain.meeting.dto.GetMeetingScheduleVoteResultResponse;
 import com.dnd.moyeolak.domain.meeting.dto.LandingStatsResponse;
+import com.dnd.moyeolak.domain.meeting.dto.MyMeetingResponse;
 import com.dnd.moyeolak.domain.meeting.dto.UpdateMeetingRequest;
 import com.dnd.moyeolak.domain.meeting.service.MeetingService;
 import com.dnd.moyeolak.global.response.ApiResponse;
@@ -39,6 +40,15 @@ public class MeetingController {
     public ResponseEntity<ApiResponse<LandingStatsResponse>> getLandingStats() {
         LandingStatsResponse stats = meetingService.getLandingStats();
         return ResponseEntity.ok(ApiResponse.success(stats));
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "내 모임 목록 조회", description = "브라우저 고유 키로 생성/참여 완료한 모임 목록을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<MyMeetingResponse>>> getMyMeetings(
+            @RequestParam String localStorageKey
+    ) {
+        List<MyMeetingResponse> myMeetings = meetingService.findMyMeetings(localStorageKey);
+        return ResponseEntity.ok(ApiResponse.success(myMeetings));
     }
 
     @GetMapping("/{meetingId}/schedules")

--- a/src/main/java/com/dnd/moyeolak/domain/meeting/dto/MyMeetingResponse.java
+++ b/src/main/java/com/dnd/moyeolak/domain/meeting/dto/MyMeetingResponse.java
@@ -1,0 +1,35 @@
+package com.dnd.moyeolak.domain.meeting.dto;
+
+import com.dnd.moyeolak.domain.meeting.entity.Meeting;
+import com.dnd.moyeolak.domain.participant.entity.Participant;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "내 모임 목록 응답")
+public record MyMeetingResponse(
+        @Schema(description = "모임 ID", example = "abc123")
+        String meetingId,
+
+        @Schema(description = "방장 이름", example = "민수")
+        String hostName,
+
+        @Schema(description = "모임 참여 인원", example = "4")
+        int participantCount,
+
+        @Schema(description = "모임 생성 시각", example = "2026-07-23T14:10:00")
+        LocalDateTime createdAt,
+
+        @Schema(description = "내 방장 여부", example = "true")
+        boolean isHost
+) {
+    public static MyMeetingResponse of(Meeting meeting, Participant myParticipant, String hostName) {
+        return new MyMeetingResponse(
+                meeting.getId(),
+                hostName,
+                meeting.getParticipantCount(),
+                meeting.getCreatedAt(),
+                myParticipant.isHost()
+        );
+    }
+}

--- a/src/main/java/com/dnd/moyeolak/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/dnd/moyeolak/domain/meeting/service/MeetingService.java
@@ -4,6 +4,7 @@ import com.dnd.moyeolak.domain.meeting.dto.CreateMeetingRequest;
 import com.dnd.moyeolak.domain.meeting.dto.GetMeetingScheduleResponse;
 import com.dnd.moyeolak.domain.meeting.dto.GetMeetingScheduleVoteResultResponse;
 import com.dnd.moyeolak.domain.meeting.dto.LandingStatsResponse;
+import com.dnd.moyeolak.domain.meeting.dto.MyMeetingResponse;
 import com.dnd.moyeolak.domain.meeting.dto.UpdateMeetingRequest;
 import com.dnd.moyeolak.domain.meeting.entity.Meeting;
 
@@ -24,6 +25,8 @@ public interface MeetingService {
     LandingStatsResponse getLandingStats();
 
     List<String> findAllMeetings();
+
+    List<MyMeetingResponse> findMyMeetings(String localStorageKey);
 
     void deleteMeeting(String meetingId);
 }

--- a/src/main/java/com/dnd/moyeolak/domain/meeting/service/impl/MeetingServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/meeting/service/impl/MeetingServiceImpl.java
@@ -5,12 +5,14 @@ import com.dnd.moyeolak.domain.meeting.dto.CreateMeetingRequest;
 import com.dnd.moyeolak.domain.meeting.dto.GetMeetingScheduleResponse;
 import com.dnd.moyeolak.domain.meeting.dto.GetMeetingScheduleVoteResultResponse;
 import com.dnd.moyeolak.domain.meeting.dto.LandingStatsResponse;
+import com.dnd.moyeolak.domain.meeting.dto.MyMeetingResponse;
 import com.dnd.moyeolak.domain.meeting.dto.UpdateMeetingRequest;
 import com.dnd.moyeolak.domain.meeting.entity.Meeting;
 import com.dnd.moyeolak.domain.meeting.repository.MeetingRepository;
 import com.dnd.moyeolak.domain.meeting.service.MeetingService;
 import com.dnd.moyeolak.domain.participant.dto.ParticipantResponse;
 import com.dnd.moyeolak.domain.participant.entity.Participant;
+import com.dnd.moyeolak.domain.participant.repository.ParticipantRepository;
 import com.dnd.moyeolak.domain.participant.service.ParticipantService;
 import com.dnd.moyeolak.domain.schedule.entity.SchedulePoll;
 import com.dnd.moyeolak.domain.schedule.entity.ScheduleVote;
@@ -32,6 +34,7 @@ import java.util.List;
 public class MeetingServiceImpl implements MeetingService {
 
     private final MeetingRepository meetingRepository;
+    private final ParticipantRepository participantRepository;
     private final ParticipantService participantService;
     private final ScheduleVoteService scheduleVoteService;
     private final Clock clock;
@@ -117,6 +120,26 @@ public class MeetingServiceImpl implements MeetingService {
     @Override
     public List<String> findAllMeetings() {
         return meetingRepository.findAllMeetingsId();
+    }
+
+    @Override
+    public List<MyMeetingResponse> findMyMeetings(String localStorageKey) {
+        if (localStorageKey == null || localStorageKey.isBlank()) {
+            return List.of();
+        }
+
+        return participantRepository.findAllByLocalStorageKeyWithMeetingAndParticipants(localStorageKey).stream()
+                .map(participant -> {
+                    Meeting meeting = participant.getMeeting();
+                    String hostName = meeting.getParticipants().stream()
+                            .filter(Participant::isHost)
+                            .findFirst()
+                            .map(Participant::getName)
+                            .orElse("방장");
+
+                    return MyMeetingResponse.of(meeting, participant, hostName);
+                })
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/dnd/moyeolak/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/com/dnd/moyeolak/domain/participant/repository/ParticipantRepository.java
@@ -3,7 +3,10 @@ package com.dnd.moyeolak.domain.participant.repository;
 import com.dnd.moyeolak.domain.meeting.entity.Meeting;
 import com.dnd.moyeolak.domain.participant.entity.Participant;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
@@ -11,4 +14,15 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
     boolean existsByMeetingAndLocalStorageKey(Meeting meeting, String localStorageKey);
 
     Optional<Participant> findByMeetingIdAndLocalStorageKey(String meetingId, String localStorageKey);
+
+    @Query("""
+        SELECT DISTINCT p FROM Participant p
+        JOIN FETCH p.meeting m
+        LEFT JOIN FETCH m.participants participants
+        WHERE p.localStorageKey = :localStorageKey
+        ORDER BY m.createdAt DESC
+    """)
+    List<Participant> findAllByLocalStorageKeyWithMeetingAndParticipants(
+            @Param("localStorageKey") String localStorageKey
+    );
 }

--- a/src/main/java/com/dnd/moyeolak/global/config/CorsConfig.java
+++ b/src/main/java/com/dnd/moyeolak/global/config/CorsConfig.java
@@ -4,17 +4,24 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
+
+    public static List<String> allowedOrigins() {
+        return List.of(
+                "http://localhost:5173",
+                "http://127.0.0.1:5173",
+                "https://dnd-14th-8-frontend.pages.dev",
+                "https://moyeorak.site"
+        );
+    }
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
-                .allowedOrigins(
-                        "http://localhost:5173",
-                        "https://dnd-14th-8-frontend.pages.dev",
-                        "https://moyeorak.site"
-                )
+                .allowedOrigins(allowedOrigins().toArray(String[]::new))
                 .allowedOriginPatterns(
                         "https://*.dnd-14th-8-frontend.pages.dev"
                 )

--- a/src/main/java/com/dnd/moyeolak/global/exception/GlobalExceptionAdvice.java
+++ b/src/main/java/com/dnd/moyeolak/global/exception/GlobalExceptionAdvice.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.HashMap;
@@ -49,6 +50,19 @@ public class GlobalExceptionAdvice {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(ApiResponse.error(ErrorCode.INVALID_PARAMETER, errors));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleMissingServletRequestParameter(
+            MissingServletRequestParameterException ex) {
+
+        Map<String, String> errors = Map.of(ex.getParameterName(), "필수 요청 파라미터입니다.");
+
+        log.warn("필수 요청 파라미터 누락: {}", errors);
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(ErrorCode.MISSING_REQUIRED_FIELD, errors));
     }
 
     @ExceptionHandler(DataIntegrityViolationException.class)

--- a/src/test/java/com/dnd/moyeolak/domain/meeting/controller/MeetingControllerTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/meeting/controller/MeetingControllerTest.java
@@ -1,6 +1,7 @@
 package com.dnd.moyeolak.domain.meeting.controller;
 
 import com.dnd.moyeolak.domain.meeting.dto.LandingStatsResponse;
+import com.dnd.moyeolak.domain.meeting.dto.MyMeetingResponse;
 import com.dnd.moyeolak.domain.meeting.service.MeetingService;
 import com.dnd.moyeolak.global.exception.GlobalExceptionAdvice;
 import com.dnd.moyeolak.global.response.SuccessCode;
@@ -13,6 +14,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -22,6 +26,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ExtendWith(MockitoExtension.class)
 class MeetingControllerTest {
+
+    private static final String LOCAL_STORAGE_KEY = "local-storage-key";
 
     @Mock
     private MeetingService meetingService;
@@ -50,5 +56,43 @@ class MeetingControllerTest {
                 .andExpect(jsonPath("$.data.todayCreatedMeetingCount").value(128));
 
         verify(meetingService).getLandingStats();
+    }
+
+    @Test
+    @DisplayName("내 모임 목록 조회 API는 200 상태와 모임 목록을 반환한다")
+    void getMyMeetings_returnsOkResponse() throws Exception {
+        // given
+        List<MyMeetingResponse> response = List.of(
+                new MyMeetingResponse(
+                        "meeting-id",
+                        "민수",
+                        4,
+                        LocalDateTime.of(2026, 7, 23, 14, 10),
+                        true
+                )
+        );
+        when(meetingService.findMyMeetings(LOCAL_STORAGE_KEY)).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/meetings/me")
+                        .param("localStorageKey", LOCAL_STORAGE_KEY))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(SuccessCode.OK.getCode()))
+                .andExpect(jsonPath("$.data[0].meetingId").value("meeting-id"))
+                .andExpect(jsonPath("$.data[0].hostName").value("민수"))
+                .andExpect(jsonPath("$.data[0].participantCount").value(4))
+                .andExpect(jsonPath("$.data[0].createdAt").value("2026-07-23T14:10:00"))
+                .andExpect(jsonPath("$.data[0].isHost").value(true));
+
+        verify(meetingService).findMyMeetings(LOCAL_STORAGE_KEY);
+    }
+
+    @Test
+    @DisplayName("내 모임 목록 조회 API는 localStorageKey가 없으면 400을 반환한다")
+    void getMyMeetings_returnsBadRequestWhenLocalStorageKeyMissing() throws Exception {
+        mockMvc.perform(get("/api/meetings/me"))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/com/dnd/moyeolak/domain/meeting/service/MeetingServiceIntegrationTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/meeting/service/MeetingServiceIntegrationTest.java
@@ -3,6 +3,7 @@ package com.dnd.moyeolak.domain.meeting.service;
 import com.dnd.moyeolak.domain.location.entity.LocationPoll;
 import com.dnd.moyeolak.domain.meeting.dto.CreateMeetingRequest;
 import com.dnd.moyeolak.domain.meeting.dto.GetMeetingScheduleResponse;
+import com.dnd.moyeolak.domain.meeting.dto.MyMeetingResponse;
 import com.dnd.moyeolak.domain.meeting.dto.UpdateMeetingRequest;
 import com.dnd.moyeolak.domain.meeting.entity.Meeting;
 import com.dnd.moyeolak.domain.meeting.repository.MeetingRepository;
@@ -20,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -428,6 +430,41 @@ class MeetingServiceIntegrationTest {
                     .isInstanceOf(BusinessException.class);
         }
 
+    }
+
+    @Nested
+    @DisplayName("내 모임 조회")
+    class FindMyMeetings {
+
+        @Test
+        @DisplayName("localStorageKey가 일치하는 모임만 조회한다")
+        void findMyMeetings_returnsOnlyMeetingsForLocalStorageKey() {
+            // given
+            String myKey = "my-local-storage-key";
+            String myMeetingId = meetingService.createMeeting(new CreateMeetingRequest(
+                    4,
+                    myKey,
+                    "민수"
+            ));
+            meetingService.createMeeting(new CreateMeetingRequest(
+                    3,
+                    "other-local-storage-key",
+                    "지영"
+            ));
+            em.flush();
+            em.clear();
+
+            // when
+            List<MyMeetingResponse> responses = meetingService.findMyMeetings(myKey);
+
+            // then
+            assertThat(responses).hasSize(1);
+            assertThat(responses.getFirst().meetingId()).isEqualTo(myMeetingId);
+            assertThat(responses.getFirst().hostName()).isEqualTo("민수");
+            assertThat(responses.getFirst().participantCount()).isEqualTo(4);
+            assertThat(responses.getFirst().isHost()).isTrue();
+            assertThat(responses.getFirst().createdAt()).isNotNull();
+        }
     }
 
     private String createTestMeeting() {

--- a/src/test/java/com/dnd/moyeolak/domain/meeting/service/MeetingServiceUnitTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/meeting/service/MeetingServiceUnitTest.java
@@ -2,10 +2,12 @@ package com.dnd.moyeolak.domain.meeting.service;
 
 import com.dnd.moyeolak.domain.location.entity.LocationPoll;
 import com.dnd.moyeolak.domain.meeting.dto.GetMeetingScheduleResponse;
+import com.dnd.moyeolak.domain.meeting.dto.MyMeetingResponse;
 import com.dnd.moyeolak.domain.meeting.entity.Meeting;
 import com.dnd.moyeolak.domain.meeting.repository.MeetingRepository;
 import com.dnd.moyeolak.domain.meeting.service.impl.MeetingServiceImpl;
 import com.dnd.moyeolak.domain.participant.entity.Participant;
+import com.dnd.moyeolak.domain.participant.repository.ParticipantRepository;
 import com.dnd.moyeolak.domain.schedule.entity.SchedulePoll;
 import com.dnd.moyeolak.domain.schedule.entity.ScheduleVote;
 import com.dnd.moyeolak.global.enums.PollStatus;
@@ -17,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -40,6 +43,9 @@ class MeetingServiceUnitTest {
 
     @Mock
     private Clock clock;
+
+    @Mock
+    private ParticipantRepository participantRepository;
 
     @InjectMocks
     private MeetingServiceImpl meetingService;
@@ -190,6 +196,62 @@ class MeetingServiceUnitTest {
 
         // then
         assertThat(response.todayCreatedMeetingCount()).isEqualTo(128L);
+    }
+
+    @Test
+    @DisplayName("내 모임 조회 시 localStorageKey에 연결된 모임 요약 목록을 반환한다")
+    void findMyMeetings_returnsMeetingSummaries() {
+        // given
+        String localStorageKey = "my-session-key";
+        LocalDateTime createdAt = LocalDateTime.of(2026, 7, 23, 14, 10);
+        Meeting meeting = Meeting.of(4);
+        ReflectionTestUtils.setField(meeting, "id", "meeting-id");
+        ReflectionTestUtils.setField(meeting, "createdAt", createdAt);
+
+        Participant host = Participant.hostOf(meeting, localStorageKey, "민수");
+        meeting.addParticipant(host);
+        meeting.addParticipant(Participant.of(meeting, "other-session-key", "지영"));
+
+        when(participantRepository.findAllByLocalStorageKeyWithMeetingAndParticipants(localStorageKey))
+                .thenReturn(List.of(host));
+
+        // when
+        List<MyMeetingResponse> responses = meetingService.findMyMeetings(localStorageKey);
+
+        // then
+        assertThat(responses).hasSize(1);
+        MyMeetingResponse response = responses.getFirst();
+        assertThat(response.meetingId()).isEqualTo("meeting-id");
+        assertThat(response.hostName()).isEqualTo("민수");
+        assertThat(response.participantCount()).isEqualTo(4);
+        assertThat(response.createdAt()).isEqualTo(createdAt);
+        assertThat(response.isHost()).isTrue();
+    }
+
+    @Test
+    @DisplayName("내 모임 조회 시 참여자로 속한 모임은 isHost false로 반환한다")
+    void findMyMeetings_returnsParticipantRole() {
+        // given
+        String localStorageKey = "participant-session-key";
+        Meeting meeting = Meeting.of(3);
+        ReflectionTestUtils.setField(meeting, "id", "meeting-id");
+        ReflectionTestUtils.setField(meeting, "createdAt", LocalDateTime.of(2026, 7, 23, 15, 30));
+
+        Participant host = Participant.hostOf(meeting, "host-session-key", "지영");
+        Participant participant = Participant.of(meeting, localStorageKey, "민수");
+        meeting.addParticipant(host);
+        meeting.addParticipant(participant);
+
+        when(participantRepository.findAllByLocalStorageKeyWithMeetingAndParticipants(localStorageKey))
+                .thenReturn(List.of(participant));
+
+        // when
+        List<MyMeetingResponse> responses = meetingService.findMyMeetings(localStorageKey);
+
+        // then
+        assertThat(responses).hasSize(1);
+        assertThat(responses.getFirst().hostName()).isEqualTo("지영");
+        assertThat(responses.getFirst().isHost()).isFalse();
     }
 
     private Meeting createMeetingWithAllAssociations() {

--- a/src/test/java/com/dnd/moyeolak/global/config/CorsConfigTest.java
+++ b/src/test/java/com/dnd/moyeolak/global/config/CorsConfigTest.java
@@ -1,0 +1,15 @@
+package com.dnd.moyeolak.global.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CorsConfigTest {
+
+    @Test
+    @DisplayName("로컬 Vite 개발 서버의 127.0.0.1 Origin을 허용한다")
+    void allowedOrigins_containsLocalViteLoopbackOrigin() {
+        assertThat(CorsConfig.allowedOrigins()).contains("http://127.0.0.1:5173");
+    }
+}


### PR DESCRIPTION
## 변경 사항
- 브라우저 고유 키 기준으로 생성/참여 완료한 모임을 조회하는 `GET /api/meetings/me` API를 추가했습니다.
- 응답에 모임 ID, 방장 이름, 참여 정원, 생성 시각, 방장 여부를 포함했습니다.
- 필수 요청 파라미터 누락 시 400 응답으로 내려가도록 예외 처리를 추가했습니다.
- 로컬 프론트 실행 주소 `http://127.0.0.1:5173`을 CORS 허용 origin에 추가했습니다.

## 검증
- `./gradlew test --tests "com.dnd.moyeolak.global.config.CorsConfigTest" --tests "com.dnd.moyeolak.domain.meeting.service.MeetingServiceIntegrationTest" --tests "com.dnd.moyeolak.domain.meeting.service.MeetingServiceUnitTest" --tests "com.dnd.moyeolak.domain.meeting.controller.MeetingControllerTest"`

Related: #156
