### PR TITLE
fix(location): 중간지점 추천 캐시/트랜잭션 처리 개선

### DIFF
--- a/src/main/java/com/dnd/moyeolak/domain/location/repository/LocationVoteRepository.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/repository/LocationVoteRepository.java
@@ -2,12 +2,18 @@ package com.dnd.moyeolak.domain.location.repository;
 
 import com.dnd.moyeolak.domain.location.entity.LocationVote;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface LocationVoteRepository extends JpaRepository<LocationVote, Long> {
-    List<LocationVote> findByLocationPoll_Id(Long locationPollId);
+
+    // participant를 fetch join으로 함께 조회 — 지연 로딩으로 인해 트랜잭션 밖에서 접근 시
+    // LazyInitializationException이 발생하는 것을 막는다 (중간지점 추천 계산에서 사용)
+    @Query("SELECT lv FROM LocationVote lv LEFT JOIN FETCH lv.participant WHERE lv.locationPoll.id = :locationPollId")
+    List<LocationVote> findByLocationPoll_Id(@Param("locationPollId") Long locationPollId);
 
     Optional<LocationVote> findFirstByParticipant_IdOrderByCreatedAtDesc(Long participantId);
 }

--- a/src/main/java/com/dnd/moyeolak/domain/location/service/impl/LocationVoteServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/service/impl/LocationVoteServiceImpl.java
@@ -14,7 +14,9 @@ import com.dnd.moyeolak.domain.participant.service.ParticipantService;
 import com.dnd.moyeolak.global.exception.BusinessException;
 import com.dnd.moyeolak.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -30,12 +32,15 @@ public class LocationVoteServiceImpl implements LocationVoteService {
     private final MeetingRepository meetingRepository;
     private final ParticipantService participantService;
     private final LocationVoteRepository locationVoteRepository;
+    private final CacheManager cacheManager;
 
     // 수도권 전철망 커버리지 기준 서비스 지역 (남: 신창 36.77, 북: 소요산 37.95, 서: 인천 126.45, 동: 춘천 127.73 + 여유분)
     private static final double SERVICE_AREA_MIN_LAT = 36.5;
     private static final double SERVICE_AREA_MAX_LAT = 38.2;
     private static final double SERVICE_AREA_MIN_LNG = 126.2;
     private static final double SERVICE_AREA_MAX_LNG = 128.0;
+
+    private static final String MIDPOINT_CACHE_NAME = "midpointRecommendations";
 
     @Override
     public List<LocationVoteResponse> listLocationVote(String meetingId) {
@@ -55,18 +60,19 @@ public class LocationVoteServiceImpl implements LocationVoteService {
 
     @Override
     @Transactional
-    @CacheEvict(value = "midpointRecommendations", allEntries = true)
     public void updateLocationVote(Long locationVoteId, UpdateLocationVoteRequest request) {
         validateServiceArea(request.departureLat(), request.departureLng());
 
         LocationVote locationVote = locationVoteRepository.findById(locationVoteId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.LOCATION_VOTE_NOT_FOUND));
+        String meetingId = locationVote.getLocationPoll().getMeeting().getId();
         locationVote.update(request);
+
+        evictMidpointCache(meetingId);
     }
 
     @Override
     @Transactional
-    @CacheEvict(value = "midpointRecommendations", allEntries = true)
     public Long createLocationVote(CreateLocationVoteRequest request) {
         validateServiceArea(request.departureLat(), request.departureLng());
 
@@ -87,11 +93,13 @@ public class LocationVoteServiceImpl implements LocationVoteService {
             }
             participant.addLocationVote(locationVote);
             locationVoteRepository.save(locationVote);
+            evictMidpointCache(request.meetingId());
             return locationVote.getId();
         }
 
         if (!StringUtils.hasText(request.localStorageKey())) {
             locationVoteRepository.save(locationVote);
+            evictMidpointCache(request.meetingId());
             return locationVote.getId();
         }
 
@@ -106,6 +114,7 @@ public class LocationVoteServiceImpl implements LocationVoteService {
             }
             participant.addLocationVote(locationVote);
             locationVoteRepository.save(locationVote);
+            evictMidpointCache(request.meetingId());
             return locationVote.getId();
         }
 
@@ -113,8 +122,21 @@ public class LocationVoteServiceImpl implements LocationVoteService {
                 Meeting.ofId(request.meetingId()), request.localStorageKey(), request.participantName(), locationVote
         );
         participantService.save(participant);
+        evictMidpointCache(request.meetingId());
 
         return locationVote.getId();
+    }
+
+    /**
+     * 캐시 키가 {@code meetingId + '_' + departureTime} 형태이므로, {@code meetingId} prefix로 시작하는
+     * 엔트리만 골라 지운다. {@code @CacheEvict(allEntries = true)}처럼 무관한 모임의 캐시까지 지우지 않기 위함.
+     */
+    private void evictMidpointCache(String meetingId) {
+        Cache cache = cacheManager.getCache(MIDPOINT_CACHE_NAME);
+        if (cache instanceof CaffeineCache caffeineCache) {
+            caffeineCache.getNativeCache().asMap().keySet()
+                    .removeIf(key -> key.toString().startsWith(meetingId + "_"));
+        }
     }
 
     private void validateServiceArea(String departureLat, String departureLng) {
@@ -135,10 +157,12 @@ public class LocationVoteServiceImpl implements LocationVoteService {
 
     @Override
     @Transactional
-    @CacheEvict(value = "midpointRecommendations", allEntries = true)
     public void deleteLocationVote(Long locationVoteId) {
         LocationVote locationVote = locationVoteRepository.findById(locationVoteId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.LOCATION_VOTE_NOT_FOUND));
+        String meetingId = locationVote.getLocationPoll().getMeeting().getId();
         locationVoteRepository.delete(locationVote);
+
+        evictMidpointCache(meetingId);
     }
 }

--- a/src/main/java/com/dnd/moyeolak/domain/location/service/impl/MidpointRecommendationServiceImpl.java
+++ b/src/main/java/com/dnd/moyeolak/domain/location/service/impl/MidpointRecommendationServiceImpl.java
@@ -21,9 +21,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -35,7 +36,6 @@ import java.util.stream.IntStream;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class MidpointRecommendationServiceImpl implements MidpointRecommendationService {
 
     private final MeetingService meetingService;
@@ -44,6 +44,7 @@ public class MidpointRecommendationServiceImpl implements MidpointRecommendation
     private final GoogleRoutesClient googleRoutesClient;
     private final KakaoDirectionsClient kakaoDirectionsClient;
     private final MidpointRecommendationUsageLimiter usageLimiter;
+    private final TransactionTemplate readOnlyTransactionTemplate;
 
     private static final int SEARCH_RADIUS_METERS = 5000;
     private static final int MAX_CANDIDATE_STATIONS = 10;
@@ -54,15 +55,56 @@ public class MidpointRecommendationServiceImpl implements MidpointRecommendation
     private static final int WALKING_SPEED_METERS_PER_MINUTE = 80;
     // KakaoDirectionsClient의 Semaphore 허용치(5)에 맞춘 병렬도 — 더 늘려도 세마포어에서 대기만 한다
     private static final int DRIVING_ENRICHMENT_THREADS = 5;
+    // 캐시 키 계산에만 쓰는 출발 시각 라운딩 단위 — 실제 외부 API 호출에 넘기는 departureTime에는 영향 없음
+    private static final int CACHE_KEY_ROUND_MINUTES = 10;
 
     @Override
-    @Cacheable(value = "midpointRecommendations", key = "#meetingId + '_' + #departureTime")
+    @Cacheable(value = "midpointRecommendations",
+            key = "#meetingId + '_' + T(com.dnd.moyeolak.domain.location.service.impl.MidpointRecommendationServiceImpl)"
+                    + ".roundDepartureTimeForCacheKey(#departureTime)")
     public MidpointRecommendationResponse calculateMidpointRecommendations(
             String meetingId,
             LocalDateTime departureTime,
             String clientIp
     ) {
-        // 1. 출발지 데이터 조회
+        // 1~3. 출발지/무게중심/후보역 조회 — DB 조회만 짧은 트랜잭션으로 묶고,
+        // Google/Kakao 외부 API 호출은 트랜잭션 밖에서 수행해 DB 커넥션 점유 시간을 줄인다.
+        MidpointQueryResult queryResult = readOnlyTransactionTemplate.execute(status -> loadQueryResult(meetingId));
+
+        usageLimiter.checkAndIncrease(meetingId, clientIp);
+
+        // 4. Google 매트릭스 1회로 전 후보역의 대중교통 시간 계산
+        List<List<TransitRouteResult>> transitMatrix = googleRoutesClient.computeTransitMatrix(
+                queryResult.votes().stream()
+                        .map(v -> new LatLng(v.getDepartureLat().doubleValue(), v.getDepartureLng().doubleValue()))
+                        .toList(),
+                queryResult.candidateStations().stream()
+                        .map(s -> new LatLng(s.getLatitude(), s.getLongitude()))
+                        .toList(),
+                departureTime
+        );
+
+        // 5. 평균 대중교통 시간으로 Top 3 선정
+        List<StationEvaluation> topStations = selectTopStations(
+                queryResult.votes(), queryResult.candidateStations(), transitMatrix, queryResult.centerPoint()
+        );
+
+        // 6. Top 3에만 Kakao 자동차 경로 보강 후 응답 조립
+        List<StationRecommendationDto> recommendations =
+                buildRecommendations(queryResult.votes(), topStations, departureTime);
+        MidpointResultType resultType = resolveResultType(queryResult.votes(), recommendations);
+
+        return new MidpointRecommendationResponse(
+                queryResult.centerPoint(), recommendations, departureTime,
+                queryResult.votes().size(), queryResult.participantCount(), resultType
+        );
+    }
+
+    /**
+     * meeting/출발지 투표 조회 → 무게중심 계산 → 후보역 검색까지의 DB 조회 구간.
+     * {@link #calculateMidpointRecommendations}에서 {@code readOnlyTransactionTemplate}으로 감싸 호출한다.
+     */
+    private MidpointQueryResult loadQueryResult(String meetingId) {
         Meeting meeting = meetingService.get(meetingId);
         LocationPoll locationPoll = meeting.getLocationPoll();
         if (locationPoll == null) {
@@ -77,11 +119,9 @@ public class MidpointRecommendationServiceImpl implements MidpointRecommendation
             );
         }
 
-        // 2. PostGIS로 무게중심 계산
         CenterPointDto centerPoint = calculateCentroid(votes);
         log.info("무게중심 계산 완료: lat={}, lng={}", centerPoint.latitude(), centerPoint.longitude());
 
-        // 3. PostGIS로 근처 지하철역 검색
         List<Station> candidateStations = stationRepository.findNearbyStations(
                 centerPoint.latitude(),
                 centerPoint.longitude(),
@@ -93,31 +133,27 @@ public class MidpointRecommendationServiceImpl implements MidpointRecommendation
         }
         log.info("후보 지하철역 {}개 검색 완료", candidateStations.size());
 
-        usageLimiter.checkAndIncrease(meetingId, clientIp);
-
-        // 4. Google 매트릭스 1회로 전 후보역의 대중교통 시간 계산
-        List<List<TransitRouteResult>> transitMatrix = googleRoutesClient.computeTransitMatrix(
-                votes.stream()
-                        .map(v -> new LatLng(v.getDepartureLat().doubleValue(), v.getDepartureLng().doubleValue()))
-                        .toList(),
-                candidateStations.stream()
-                        .map(s -> new LatLng(s.getLatitude(), s.getLongitude()))
-                        .toList(),
-                departureTime
-        );
-
-        // 5. 평균 대중교통 시간으로 Top 3 선정
-        List<StationEvaluation> topStations = selectTopStations(votes, candidateStations, transitMatrix, centerPoint);
-
-        // 6. Top 3에만 Kakao 자동차 경로 보강 후 응답 조립
-        List<StationRecommendationDto> recommendations = buildRecommendations(votes, topStations, departureTime);
-        MidpointResultType resultType = resolveResultType(votes, recommendations);
-
-        return new MidpointRecommendationResponse(
-                centerPoint, recommendations, departureTime,
-                votes.size(), meeting.getParticipantCount(), resultType
-        );
+        return new MidpointQueryResult(votes, centerPoint, candidateStations, meeting.getParticipantCount());
     }
+
+    /**
+     * 캐시 키 계산에만 사용하는 출발 시각 정규화. {@code departureTime}이 null이면(=지금 출발) 고정 버킷을 쓰고,
+     * 값이 있으면 {@link #CACHE_KEY_ROUND_MINUTES}분 단위로 내림해 초 단위 차이로 캐시가 무력화되지 않게 한다.
+     */
+    public static String roundDepartureTimeForCacheKey(LocalDateTime departureTime) {
+        if (departureTime == null) {
+            return "now";
+        }
+        int roundedMinute = (departureTime.getMinute() / CACHE_KEY_ROUND_MINUTES) * CACHE_KEY_ROUND_MINUTES;
+        return departureTime.withMinute(roundedMinute).truncatedTo(ChronoUnit.MINUTES).toString();
+    }
+
+    private record MidpointQueryResult(
+            List<LocationVote> votes,
+            CenterPointDto centerPoint,
+            List<Station> candidateStations,
+            int participantCount
+    ) {}
 
     private MidpointResultType resolveResultType(List<LocationVote> votes, List<StationRecommendationDto> recommendations) {
         if (votes.size() < 2 || recommendations.isEmpty()) {

--- a/src/main/java/com/dnd/moyeolak/global/config/TransactionTemplateConfig.java
+++ b/src/main/java/com/dnd/moyeolak/global/config/TransactionTemplateConfig.java
@@ -1,0 +1,17 @@
+package com.dnd.moyeolak.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Configuration
+public class TransactionTemplateConfig {
+
+    @Bean
+    public TransactionTemplate readOnlyTransactionTemplate(PlatformTransactionManager transactionManager) {
+        TransactionTemplate template = new TransactionTemplate(transactionManager);
+        template.setReadOnly(true);
+        return template;
+    }
+}

--- a/src/test/java/com/dnd/moyeolak/domain/location/service/LocationVoteUnitTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/location/service/LocationVoteUnitTest.java
@@ -6,12 +6,15 @@ import com.dnd.moyeolak.domain.location.entity.LocationPoll;
 import com.dnd.moyeolak.domain.location.entity.LocationVote;
 import com.dnd.moyeolak.domain.location.repository.LocationVoteRepository;
 import com.dnd.moyeolak.domain.location.service.impl.LocationVoteServiceImpl;
+import com.dnd.moyeolak.domain.meeting.dto.UpdateLocationVoteRequest;
 import com.dnd.moyeolak.domain.meeting.entity.Meeting;
 import com.dnd.moyeolak.domain.meeting.repository.MeetingRepository;
 import com.dnd.moyeolak.domain.participant.entity.Participant;
 import com.dnd.moyeolak.domain.participant.service.ParticipantService;
 import com.dnd.moyeolak.global.exception.BusinessException;
 import com.dnd.moyeolak.global.response.ErrorCode;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -20,6 +23,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
@@ -42,6 +48,9 @@ class LocationVoteUnitTest {
 
     @Mock
     private LocationVoteRepository locationVoteRepository;
+
+    @Mock
+    private CacheManager cacheManager;
 
     @InjectMocks
     private LocationVoteServiceImpl locationService;
@@ -563,6 +572,101 @@ class LocationVoteUnitTest {
             assertThatThrownBy(() -> locationService.listLocationVote(meetingId))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.LOCATION_POLL_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("캐시 무효화 범위")
+    class CacheEviction {
+
+        private static final String CACHE_NAME = "midpointRecommendations";
+
+        private CacheManager realCacheManager;
+        private LocationVoteServiceImpl serviceWithRealCache;
+
+        @BeforeEach
+        void setUp() {
+            CaffeineCacheManager caffeineCacheManager = new CaffeineCacheManager(CACHE_NAME);
+            caffeineCacheManager.setCaffeine(Caffeine.newBuilder());
+            realCacheManager = caffeineCacheManager;
+            serviceWithRealCache = new LocationVoteServiceImpl(
+                    meetingRepository, participantService, locationVoteRepository, realCacheManager
+            );
+        }
+
+        @Test
+        @DisplayName("출발지 생성 시 해당 모임의 캐시만 무효화되고 다른 모임의 캐시는 유지된다")
+        void createLocationVote_evictsOnlyTargetMeetingCache() {
+            // given
+            Cache cache = realCacheManager.getCache(CACHE_NAME);
+            cache.put("meeting-A_now", "cached-A");
+            cache.put("meeting-B_now", "cached-B");
+
+            when(meetingRepository.findByIdWithAllAssociations("meeting-A"))
+                    .thenReturn(Optional.of(Meeting.ofId("meeting-A")));
+
+            CreateLocationVoteRequest request = new CreateLocationVoteRequest(
+                    "meeting-A", null, null, "홍길동", "서울시 강남구", "37.4979502", "127.0276368"
+            );
+
+            // when
+            serviceWithRealCache.createLocationVote(request);
+
+            // then
+            assertThat(cache.get("meeting-A_now")).isNull();
+            assertThat(cache.get("meeting-B_now").get()).isEqualTo("cached-B");
+        }
+
+        @Test
+        @DisplayName("출발지 수정 시 해당 모임의 캐시만 무효화되고 다른 모임의 캐시는 유지된다")
+        void updateLocationVote_evictsOnlyTargetMeetingCache() {
+            // given
+            Cache cache = realCacheManager.getCache(CACHE_NAME);
+            cache.put("meeting-A_now", "cached-A");
+            cache.put("meeting-B_now", "cached-B");
+
+            Meeting meetingA = Meeting.ofId("meeting-A");
+            LocationPoll locationPollA = LocationPoll.defaultOf(meetingA);
+            LocationVote voteA = LocationVote.of(
+                    locationPollA, "참가자", "서울시 강남구",
+                    new BigDecimal("37.4979502"), new BigDecimal("127.0276368")
+            );
+            when(locationVoteRepository.findById(1L)).thenReturn(Optional.of(voteA));
+
+            UpdateLocationVoteRequest request = new UpdateLocationVoteRequest(
+                    "참가자", "서울시 홍대입구", "37.5571010", "126.9236450"
+            );
+
+            // when
+            serviceWithRealCache.updateLocationVote(1L, request);
+
+            // then
+            assertThat(cache.get("meeting-A_now")).isNull();
+            assertThat(cache.get("meeting-B_now").get()).isEqualTo("cached-B");
+        }
+
+        @Test
+        @DisplayName("출발지 삭제 시 해당 모임의 캐시만 무효화되고 다른 모임의 캐시는 유지된다")
+        void deleteLocationVote_evictsOnlyTargetMeetingCache() {
+            // given
+            Cache cache = realCacheManager.getCache(CACHE_NAME);
+            cache.put("meeting-A_now", "cached-A");
+            cache.put("meeting-B_now", "cached-B");
+
+            Meeting meetingA = Meeting.ofId("meeting-A");
+            LocationPoll locationPollA = LocationPoll.defaultOf(meetingA);
+            LocationVote voteA = LocationVote.of(
+                    locationPollA, "참가자", "서울시 강남구",
+                    new BigDecimal("37.4979502"), new BigDecimal("127.0276368")
+            );
+            when(locationVoteRepository.findById(1L)).thenReturn(Optional.of(voteA));
+
+            // when
+            serviceWithRealCache.deleteLocationVote(1L);
+
+            // then
+            assertThat(cache.get("meeting-A_now")).isNull();
+            assertThat(cache.get("meeting-B_now").get()).isEqualTo("cached-B");
         }
     }
 }

--- a/src/test/java/com/dnd/moyeolak/domain/location/service/MidpointRecommendationServiceImplTest.java
+++ b/src/test/java/com/dnd/moyeolak/domain/location/service/MidpointRecommendationServiceImplTest.java
@@ -19,6 +19,7 @@ import com.dnd.moyeolak.global.ratelimit.MidpointRecommendationUsageLimiter;
 import com.dnd.moyeolak.global.response.ErrorCode;
 import com.dnd.moyeolak.global.station.entity.Station;
 import com.dnd.moyeolak.global.station.repository.StationRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -26,8 +27,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 
@@ -69,10 +73,22 @@ class MidpointRecommendationServiceImplTest {
     @Mock
     private MidpointRecommendationUsageLimiter usageLimiter;
 
+    @Mock
+    private TransactionTemplate readOnlyTransactionTemplate;
+
     @InjectMocks
     private MidpointRecommendationServiceImpl midpointRecommendationService;
 
     private static final String MEETING_ID = "meeting-123";
+
+    @BeforeEach
+    void setUpTransactionTemplate() {
+        // 실제 트랜잭션 없이 콜백을 즉시 실행 — DB 조회 구간만 트랜잭션으로 감싸는 구조를 단위 테스트에서 재현한다
+        lenient().when(readOnlyTransactionTemplate.execute(any())).thenAnswer(invocation -> {
+            TransactionCallback<?> callback = invocation.getArgument(0);
+            return callback.doInTransaction(null);
+        });
+    }
 
     @Nested
     @DisplayName("예외 케이스")
@@ -577,6 +593,38 @@ class MidpointRecommendationServiceImplTest {
 
             assertThat(response.recommendations().getFirst().routes().getFirst().departureName())
                     .isEqualTo("김참가자");
+        }
+    }
+
+    @Nested
+    @DisplayName("캐시 키 출발 시각 라운딩")
+    class CacheKeyRounding {
+
+        @Test
+        @DisplayName("departureTime이 null이면 고정된 키를 반환한다")
+        void roundDepartureTimeForCacheKey_null_returnsFixedKey() {
+            assertThat(MidpointRecommendationServiceImpl.roundDepartureTimeForCacheKey(null))
+                    .isEqualTo("now");
+        }
+
+        @Test
+        @DisplayName("같은 10분 버킷에 속하는 서로 다른 초 단위 시각은 같은 키로 라운딩된다")
+        void roundDepartureTimeForCacheKey_withinSameBucket_returnsSameKey() {
+            LocalDateTime t1 = LocalDateTime.of(2026, 7, 25, 15, 1, 5);
+            LocalDateTime t2 = LocalDateTime.of(2026, 7, 25, 15, 9, 59);
+
+            assertThat(MidpointRecommendationServiceImpl.roundDepartureTimeForCacheKey(t1))
+                    .isEqualTo(MidpointRecommendationServiceImpl.roundDepartureTimeForCacheKey(t2));
+        }
+
+        @Test
+        @DisplayName("다른 10분 버킷에 속하는 시각은 다른 키로 라운딩된다")
+        void roundDepartureTimeForCacheKey_differentBuckets_returnsDifferentKeys() {
+            LocalDateTime t1 = LocalDateTime.of(2026, 7, 25, 15, 9, 59);
+            LocalDateTime t2 = LocalDateTime.of(2026, 7, 25, 15, 10, 0);
+
+            assertThat(MidpointRecommendationServiceImpl.roundDepartureTimeForCacheKey(t1))
+                    .isNotEqualTo(MidpointRecommendationServiceImpl.roundDepartureTimeForCacheKey(t2));
         }
     }
 


### PR DESCRIPTION
## 요약

- `LocationVoteServiceImpl`의 `@CacheEvict(allEntries = true)`를 제거하고, `meetingId` prefix로 시작하는 캐시 엔트리만 지우도록 변경해 무관한 모임의 캐시가 함께 사라지던 문제를 해결
- `MidpointRecommendationServiceImpl`의 DB 조회 구간만 `TransactionTemplate`으로 감싸고 Google/Kakao 외부 API 호출은 트랜잭션 밖에서 수행하도록 재구성 (DB 커넥션이 외부 API 응답 대기 시간만큼 점유되는 문제 방지)
- `LocationVoteRepository.findByLocationPoll_Id`에 `LEFT JOIN FETCH participant` 추가로, 트랜잭션 종료 후 엔티티 접근 시 `LazyInitializationException` 위험 제거
- 캐시 키 계산 시 `departureTime`을 10분 단위로 내림 정규화해 초 단위 차이로 캐시가 무력화되는 것을 방지 (외부 API에 전달하는 실제 `departureTime`은 변경 없음)

Closes #161

## 테스트 플랜

- [x] `./gradlew test` 전체 통과 (56 클래스 / 211 테스트)
- [x] `LocationVoteUnitTest` — 모임 A 캐시 변경 시 모임 B 캐시가 유지되는지 확인하는 케이스 추가
- [x] `MidpointRecommendationServiceImplTest` — `TransactionTemplate` mock 패스스루 처리, 캐시 키 라운딩 단위 테스트 추가
- [x] `LocationVoteIntegrationTest` — 기존 통합 테스트 회귀 없음 확인
