### PR TITLE
외부 API quota / 일일 통계 Slack 알림 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ infra/terraform/.terraform/
 *.tfstate.*
 *.tfvars
 !*.tfvars.example
+
+### Git Worktrees ###
+.worktrees/

--- a/src/main/java/com/dnd/moyeolak/global/client/slack/SlackWebhookClient.java
+++ b/src/main/java/com/dnd/moyeolak/global/client/slack/SlackWebhookClient.java
@@ -1,0 +1,45 @@
+package com.dnd.moyeolak.global.client.slack;
+
+import com.dnd.moyeolak.global.client.slack.config.SlackApiConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+public class SlackWebhookClient {
+
+    private final RestTemplate slackRestTemplate;
+    private final SlackApiConfig slackApiConfig;
+
+    public SlackWebhookClient(
+            @Qualifier("slackRestTemplate") RestTemplate slackRestTemplate,
+            SlackApiConfig slackApiConfig
+    ) {
+        this.slackRestTemplate = slackRestTemplate;
+        this.slackApiConfig = slackApiConfig;
+    }
+
+    public void send(String message) {
+        String webhookUrl = slackApiConfig.getWebhookUrl();
+        if (webhookUrl == null || webhookUrl.isBlank()) {
+            log.warn("SLACK_WEBHOOK_URL 미설정 - 알림 전송 생략: {}", message);
+            return;
+        }
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<Map<String, String>> entity = new HttpEntity<>(Map.of("text", message), headers);
+            slackRestTemplate.postForEntity(webhookUrl, entity, String.class);
+        } catch (RestClientException e) {
+            log.error("Slack 알림 전송 실패: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/dnd/moyeolak/global/client/slack/SlackWebhookClient.java
+++ b/src/main/java/com/dnd/moyeolak/global/client/slack/SlackWebhookClient.java
@@ -7,7 +7,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Map;
@@ -27,19 +26,21 @@ public class SlackWebhookClient {
         this.slackApiConfig = slackApiConfig;
     }
 
-    public void send(String message) {
+    public boolean send(String message) {
         String webhookUrl = slackApiConfig.getWebhookUrl();
         if (webhookUrl == null || webhookUrl.isBlank()) {
             log.warn("SLACK_WEBHOOK_URL 미설정 - 알림 전송 생략: {}", message);
-            return;
+            return true;
         }
         try {
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_JSON);
             HttpEntity<Map<String, String>> entity = new HttpEntity<>(Map.of("text", message), headers);
             slackRestTemplate.postForEntity(webhookUrl, entity, String.class);
-        } catch (RestClientException e) {
-            log.error("Slack 알림 전송 실패: {}", e.getMessage());
+            return true;
+        } catch (Exception e) {
+            log.error("Slack 알림 전송 실패: {}", e.getClass().getName());
+            return false;
         }
     }
 }

--- a/src/main/java/com/dnd/moyeolak/global/client/slack/config/SlackApiConfig.java
+++ b/src/main/java/com/dnd/moyeolak/global/client/slack/config/SlackApiConfig.java
@@ -1,0 +1,26 @@
+package com.dnd.moyeolak.global.client.slack.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class SlackApiConfig {
+
+    @Value("${external-api.alert.slack-webhook-url:}")
+    private String webhookUrl;
+
+    public String getWebhookUrl() {
+        return webhookUrl;
+    }
+
+    @Bean("slackRestTemplate")
+    public RestTemplate slackRestTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(5000);
+        factory.setReadTimeout(5000);
+        return new RestTemplate(factory);
+    }
+}

--- a/src/main/java/com/dnd/moyeolak/global/metrics/MetricsSnapshotJob.java
+++ b/src/main/java/com/dnd/moyeolak/global/metrics/MetricsSnapshotJob.java
@@ -1,5 +1,6 @@
 package com.dnd.moyeolak.global.metrics;
 
+import com.dnd.moyeolak.global.metrics.alert.QuotaAlertNotifier;
 import com.dnd.moyeolak.global.metrics.entity.ExternalApiMetricSnapshot;
 import com.dnd.moyeolak.global.metrics.repository.ExternalApiMetricSnapshotRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -13,7 +14,7 @@ import java.util.List;
 
 /**
  * 주기적으로 MeterRegistry 누적값을 읽어 스냅샷 테이블에 적재하고,
- * 보관기간이 지난 스냅샷을 정리한다.
+ * 보관기간이 지난 스냅샷을 정리한다. 캡처 직후 quota 알림 여부를 검사한다.
  */
 @Slf4j
 @Component
@@ -21,17 +22,20 @@ public class MetricsSnapshotJob {
 
     private final MetricsSnapshotReader reader;
     private final ExternalApiMetricSnapshotRepository repository;
+    private final QuotaAlertNotifier quotaAlertNotifier;
     private final Clock clock;
     private final int retentionDays;
 
     public MetricsSnapshotJob(
             MetricsSnapshotReader reader,
             ExternalApiMetricSnapshotRepository repository,
+            QuotaAlertNotifier quotaAlertNotifier,
             Clock clock,
             @Value("${external-api.metrics.retention-days:30}") int retentionDays
     ) {
         this.reader = reader;
         this.repository = repository;
+        this.quotaAlertNotifier = quotaAlertNotifier;
         this.clock = clock;
         this.retentionDays = retentionDays;
     }
@@ -46,6 +50,7 @@ public class MetricsSnapshotJob {
                 .toList();
         repository.saveAll(snapshots);
         log.debug("외부 API 지표 스냅샷 {}건 저장 ({})", snapshots.size(), capturedAt);
+        quotaAlertNotifier.checkAndNotify();
     }
 
     @Scheduled(cron = "${external-api.metrics.cleanup-cron:0 30 4 * * *}")

--- a/src/main/java/com/dnd/moyeolak/global/metrics/alert/DailySummaryNotifier.java
+++ b/src/main/java/com/dnd/moyeolak/global/metrics/alert/DailySummaryNotifier.java
@@ -1,0 +1,67 @@
+package com.dnd.moyeolak.global.metrics.alert;
+
+import com.dnd.moyeolak.domain.meeting.service.MeetingService;
+import com.dnd.moyeolak.global.client.slack.SlackWebhookClient;
+import com.dnd.moyeolak.global.metrics.stats.ExternalApiStatsService;
+import com.dnd.moyeolak.global.metrics.stats.dto.ExternalApiSummaryResponse.ApiSummary;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+/**
+ * 매일 지정 시각에 오늘 생성된 모임 수와 외부 API 호출 통계를 Slack으로 요약 전송한다.
+ * 별도 계측 없이 기존 MeetingService/ExternalApiStatsService의 계산 결과를 그대로 읽는다.
+ */
+@Component
+public class DailySummaryNotifier {
+
+    private final MeetingService meetingService;
+    private final ExternalApiStatsService statsService;
+    private final SlackWebhookClient slackWebhookClient;
+    private final Clock clock;
+
+    public DailySummaryNotifier(
+            MeetingService meetingService,
+            ExternalApiStatsService statsService,
+            SlackWebhookClient slackWebhookClient,
+            Clock clock
+    ) {
+        this.meetingService = meetingService;
+        this.statsService = statsService;
+        this.slackWebhookClient = slackWebhookClient;
+        this.clock = clock;
+    }
+
+    @Scheduled(cron = "${external-api.alert.daily-summary-cron:0 50 23 * * *}")
+    public void sendDailySummary() {
+        long todayMeetingCount = meetingService.getLandingStats().todayCreatedMeetingCount();
+        List<ApiSummary> apis = statsService.summary().apis();
+        slackWebhookClient.send(buildMessage(todayMeetingCount, apis));
+    }
+
+    private String buildMessage(long todayMeetingCount, List<ApiSummary> apis) {
+        String date = LocalDate.now(clock).format(DateTimeFormatter.ISO_LOCAL_DATE);
+        StringBuilder sb = new StringBuilder();
+        sb.append(":bar_chart: 오늘의 서비스 통계 (").append(date).append(")\n\n");
+        sb.append("오늘 생성된 모임: ").append(todayMeetingCount).append("건\n\n");
+        sb.append("외부 API 호출 현황\n");
+        for (ApiSummary api : apis) {
+            sb.append(apiLine(api)).append('\n');
+        }
+        return sb.toString();
+    }
+
+    private String apiLine(ApiSummary api) {
+        if (api.dailyQuota() == null) {
+            String cost = api.todayCostUsd() == null ? "" : " 예상 비용 $%.2f".formatted(api.todayCostUsd());
+            return "• %s: %d회 호출,%s".formatted(api.api(), api.calls(), cost);
+        }
+        double usedPercent = api.dailyQuota() == 0 ? 0.0 : api.calls() * 100.0 / api.dailyQuota();
+        return "• %s: %d/%d 호출 (%.1f%%), 성공률 %.1f%%".formatted(
+                api.api(), api.calls(), api.dailyQuota(), usedPercent, api.successRate());
+    }
+}

--- a/src/main/java/com/dnd/moyeolak/global/metrics/alert/ExternalApiAlertProperties.java
+++ b/src/main/java/com/dnd/moyeolak/global/metrics/alert/ExternalApiAlertProperties.java
@@ -1,0 +1,15 @@
+package com.dnd.moyeolak.global.metrics.alert;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties("external-api.alert")
+public class ExternalApiAlertProperties {
+
+    private double thresholdPercent = 20.0;
+}

--- a/src/main/java/com/dnd/moyeolak/global/metrics/alert/QuotaAlertNotifier.java
+++ b/src/main/java/com/dnd/moyeolak/global/metrics/alert/QuotaAlertNotifier.java
@@ -45,11 +45,11 @@ public class QuotaAlertNotifier {
             if (remainingPercent >= properties.getThresholdPercent()) {
                 continue;
             }
-            if (today.equals(lastAlertedDate.get(summary.api()))) {
-                continue;
+            LocalDate previousAlertDate = lastAlertedDate.put(summary.api(), today);
+            if (today.equals(previousAlertDate)) {
+                continue; // 오늘 이미 알림을 보냈거나(또는 경쟁 스레드가 방금 기록함) - put은 어느 쪽이든 오늘 날짜로 기록됨
             }
             slackWebhookClient.send(alertMessage(summary, remainingPercent));
-            lastAlertedDate.put(summary.api(), today);
         }
     }
 

--- a/src/main/java/com/dnd/moyeolak/global/metrics/alert/QuotaAlertNotifier.java
+++ b/src/main/java/com/dnd/moyeolak/global/metrics/alert/QuotaAlertNotifier.java
@@ -49,7 +49,10 @@ public class QuotaAlertNotifier {
             if (today.equals(previousAlertDate)) {
                 continue; // 오늘 이미 알림을 보냈거나(또는 경쟁 스레드가 방금 기록함) - put은 어느 쪽이든 오늘 날짜로 기록됨
             }
-            slackWebhookClient.send(alertMessage(summary, remainingPercent));
+            boolean sent = slackWebhookClient.send(alertMessage(summary, remainingPercent));
+            if (!sent) {
+                lastAlertedDate.remove(summary.api());
+            }
         }
     }
 

--- a/src/main/java/com/dnd/moyeolak/global/metrics/alert/QuotaAlertNotifier.java
+++ b/src/main/java/com/dnd/moyeolak/global/metrics/alert/QuotaAlertNotifier.java
@@ -1,0 +1,60 @@
+package com.dnd.moyeolak.global.metrics.alert;
+
+import com.dnd.moyeolak.global.client.slack.SlackWebhookClient;
+import com.dnd.moyeolak.global.metrics.stats.ExternalApiStatsService;
+import com.dnd.moyeolak.global.metrics.stats.dto.ExternalApiSummaryResponse.ApiSummary;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 외부 API 일일 quota 잔여 비율이 임계치 미만이면 Slack으로 알림한다.
+ * quota가 없는 API(Google Routes 등 종량제)는 대상에서 제외한다.
+ */
+@Component
+public class QuotaAlertNotifier {
+
+    private final ExternalApiStatsService statsService;
+    private final SlackWebhookClient slackWebhookClient;
+    private final ExternalApiAlertProperties properties;
+    private final Clock clock;
+    private final Map<String, LocalDate> lastAlertedDate = new ConcurrentHashMap<>();
+
+    public QuotaAlertNotifier(
+            ExternalApiStatsService statsService,
+            SlackWebhookClient slackWebhookClient,
+            ExternalApiAlertProperties properties,
+            Clock clock
+    ) {
+        this.statsService = statsService;
+        this.slackWebhookClient = slackWebhookClient;
+        this.properties = properties;
+        this.clock = clock;
+    }
+
+    public void checkAndNotify() {
+        LocalDate today = LocalDate.now(clock);
+        for (ApiSummary summary : statsService.summary().apis()) {
+            if (summary.dailyQuota() == null || summary.dailyQuota() == 0) {
+                continue;
+            }
+            double remainingPercent = summary.quotaRemaining() * 100.0 / summary.dailyQuota();
+            if (remainingPercent >= properties.getThresholdPercent()) {
+                continue;
+            }
+            if (today.equals(lastAlertedDate.get(summary.api()))) {
+                continue;
+            }
+            slackWebhookClient.send(alertMessage(summary, remainingPercent));
+            lastAlertedDate.put(summary.api(), today);
+        }
+    }
+
+    private String alertMessage(ApiSummary summary, double remainingPercent) {
+        return "[quota 경고] %s 일일 호출 한도 잔여 %.1f%% (남은 %d / %d회)".formatted(
+                summary.api(), remainingPercent, summary.quotaRemaining(), summary.dailyQuota());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,7 @@ external-api:
   alert:
     threshold-percent: 20             # 일일 quota 잔여 비율이 이 값(%) 미만이면 Slack 알림
     slack-webhook-url: ${SLACK_WEBHOOK_URL:}
+    daily-summary-cron: "0 50 23 * * *"   # 매일 23:50 오늘 통계 요약 발송
 moyeolak:
   rate-limit:
     midpoint-recommendation:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,9 @@ external-api:
     # Google 과금 단가 (Basic 티어, USD). FieldMask가 Advanced 이상이면 상향 필요
     google-compute-routes-per-request: 0.005
     google-route-matrix-per-element: 0.005
+  alert:
+    threshold-percent: 20             # 일일 quota 잔여 비율이 이 값(%) 미만이면 Slack 알림
+    slack-webhook-url: ${SLACK_WEBHOOK_URL:}
 moyeolak:
   rate-limit:
     midpoint-recommendation:

--- a/src/test/java/com/dnd/moyeolak/global/client/slack/SlackWebhookClientTest.java
+++ b/src/test/java/com/dnd/moyeolak/global/client/slack/SlackWebhookClientTest.java
@@ -1,0 +1,59 @@
+package com.dnd.moyeolak.global.client.slack;
+
+import com.dnd.moyeolak.global.client.slack.config.SlackApiConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.http.HttpMethod.POST;
+
+class SlackWebhookClientTest {
+
+    private static final String WEBHOOK_URL = "https://hooks.slack.com/services/T000/B000/xxx";
+
+    private RestTemplate restTemplate;
+    private MockRestServiceServer server;
+    private SlackApiConfig config;
+    private SlackWebhookClient client;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = new RestTemplate();
+        server = MockRestServiceServer.bindTo(restTemplate).build();
+        config = new SlackApiConfig();
+        ReflectionTestUtils.setField(config, "webhookUrl", WEBHOOK_URL);
+        client = new SlackWebhookClient(restTemplate, config);
+    }
+
+    @Test
+    @DisplayName("webhook URL로 text 메시지를 JSON POST한다")
+    void sendsMessageToWebhookUrl() {
+        server.expect(requestTo(WEBHOOK_URL))
+                .andExpect(method(POST))
+                .andExpect(content().string(containsString("hello slack")))
+                .andRespond(withSuccess("ok", MediaType.TEXT_PLAIN));
+
+        client.send("hello slack");
+
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("webhook URL이 비어있으면 아무 요청도 보내지 않는다")
+    void doesNothingWhenWebhookUrlBlank() {
+        ReflectionTestUtils.setField(config, "webhookUrl", "");
+
+        client.send("hello slack");
+
+        server.verify();
+    }
+}

--- a/src/test/java/com/dnd/moyeolak/global/client/slack/SlackWebhookClientTest.java
+++ b/src/test/java/com/dnd/moyeolak/global/client/slack/SlackWebhookClientTest.java
@@ -9,9 +9,11 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.http.HttpMethod.POST;
@@ -42,9 +44,10 @@ class SlackWebhookClientTest {
                 .andExpect(content().string(containsString("hello slack")))
                 .andRespond(withSuccess("ok", MediaType.TEXT_PLAIN));
 
-        client.send("hello slack");
+        boolean sent = client.send("hello slack");
 
         server.verify();
+        assertThat(sent).isTrue();
     }
 
     @Test
@@ -52,8 +55,22 @@ class SlackWebhookClientTest {
     void doesNothingWhenWebhookUrlBlank() {
         ReflectionTestUtils.setField(config, "webhookUrl", "");
 
-        client.send("hello slack");
+        boolean sent = client.send("hello slack");
 
         server.verify();
+        assertThat(sent).isTrue();
+    }
+
+    @Test
+    @DisplayName("Slack 서버가 오류를 응답하면 예외를 던지지 않고 false를 반환한다")
+    void returnsFalseWhenServerRespondsWithError() {
+        server.expect(requestTo(WEBHOOK_URL))
+                .andExpect(method(POST))
+                .andRespond(withServerError());
+
+        boolean sent = client.send("hello slack");
+
+        server.verify();
+        assertThat(sent).isFalse();
     }
 }

--- a/src/test/java/com/dnd/moyeolak/global/metrics/MetricsSnapshotJobTest.java
+++ b/src/test/java/com/dnd/moyeolak/global/metrics/MetricsSnapshotJobTest.java
@@ -1,5 +1,6 @@
 package com.dnd.moyeolak.global.metrics;
 
+import com.dnd.moyeolak.global.metrics.alert.QuotaAlertNotifier;
 import com.dnd.moyeolak.global.metrics.entity.ExternalApiMetricSnapshot;
 import com.dnd.moyeolak.global.metrics.repository.ExternalApiMetricSnapshotRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,13 +29,15 @@ class MetricsSnapshotJobTest {
 
     private MetricsSnapshotReader reader;
     private ExternalApiMetricSnapshotRepository repository;
+    private QuotaAlertNotifier quotaAlertNotifier;
     private MetricsSnapshotJob job;
 
     @BeforeEach
     void setUp() {
         reader = mock(MetricsSnapshotReader.class);
         repository = mock(ExternalApiMetricSnapshotRepository.class);
-        job = new MetricsSnapshotJob(reader, repository, FIXED_CLOCK, RETENTION_DAYS);
+        quotaAlertNotifier = mock(QuotaAlertNotifier.class);
+        job = new MetricsSnapshotJob(reader, repository, quotaAlertNotifier, FIXED_CLOCK, RETENTION_DAYS);
     }
 
     @Test
@@ -70,6 +73,8 @@ class MetricsSnapshotJobTest {
                 .filter(s -> s.getApi().equals("google_routes")).findFirst().orElseThrow();
         assertThat(google.getComputeRoutesUnits()).isEqualTo(3);
         assertThat(google.getRouteMatrixUnits()).isEqualTo(7);
+
+        verify(quotaAlertNotifier).checkAndNotify();
     }
 
     @Test

--- a/src/test/java/com/dnd/moyeolak/global/metrics/alert/DailySummaryNotifierTest.java
+++ b/src/test/java/com/dnd/moyeolak/global/metrics/alert/DailySummaryNotifierTest.java
@@ -1,0 +1,87 @@
+package com.dnd.moyeolak.global.metrics.alert;
+
+import com.dnd.moyeolak.domain.meeting.dto.LandingStatsResponse;
+import com.dnd.moyeolak.domain.meeting.service.MeetingService;
+import com.dnd.moyeolak.global.client.slack.SlackWebhookClient;
+import com.dnd.moyeolak.global.metrics.stats.ExternalApiStatsService;
+import com.dnd.moyeolak.global.metrics.stats.dto.ExternalApiSummaryResponse;
+import com.dnd.moyeolak.global.metrics.stats.dto.ExternalApiSummaryResponse.ApiSummary;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.*;
+
+class DailySummaryNotifierTest {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-07-26T14:50:00Z"), KST);
+
+    private MeetingService meetingService;
+    private ExternalApiStatsService statsService;
+    private SlackWebhookClient slackWebhookClient;
+    private DailySummaryNotifier notifier;
+
+    @BeforeEach
+    void setUp() {
+        meetingService = mock(MeetingService.class);
+        statsService = mock(ExternalApiStatsService.class);
+        slackWebhookClient = mock(SlackWebhookClient.class);
+        when(slackWebhookClient.send(anyString())).thenReturn(true);
+        notifier = new DailySummaryNotifier(meetingService, statsService, slackWebhookClient, CLOCK);
+    }
+
+    private ApiSummary quotaApi(String api, long calls, long dailyQuota, long quotaRemaining, double successRate) {
+        return new ApiSummary(api, calls, calls, 0, successRate, 0, 0.0, dailyQuota, quotaRemaining, null);
+    }
+
+    private ApiSummary payPerUseApi(String api, long calls, double cost) {
+        return new ApiSummary(api, calls, calls, 0, 100.0, 0, 0.0, null, null, cost);
+    }
+
+    @Test
+    @DisplayName("오늘 생성된 모임 수와 API별 통계를 하나의 Slack 메시지로 전송한다")
+    void sendsCombinedDailySummary() {
+        when(meetingService.getLandingStats()).thenReturn(new LandingStatsResponse(12));
+        when(statsService.summary()).thenReturn(new ExternalApiSummaryResponse(
+                LocalDateTime.now(CLOCK),
+                List.of(
+                        quotaApi("odsay", 342, 1000, 658, 98.2),
+                        payPerUseApi("google_routes", 130, 0.65)
+                )));
+
+        notifier.sendDailySummary();
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(slackWebhookClient).send(captor.capture());
+        String message = captor.getValue();
+
+        assertThat(message).contains("12건");
+        assertThat(message).contains("odsay");
+        assertThat(message).contains("342");
+        assertThat(message).contains("1000");
+        assertThat(message).contains("google_routes");
+        assertThat(message).contains("0.65");
+    }
+
+    @Test
+    @DisplayName("모임이 0건이어도 정상적으로 메시지를 보낸다")
+    void sendsSummaryEvenWhenNoMeetingsToday() {
+        when(meetingService.getLandingStats()).thenReturn(new LandingStatsResponse(0));
+        when(statsService.summary()).thenReturn(new ExternalApiSummaryResponse(
+                LocalDateTime.now(CLOCK), List.of()));
+
+        notifier.sendDailySummary();
+
+        verify(slackWebhookClient).send(contains("0건"));
+    }
+}

--- a/src/test/java/com/dnd/moyeolak/global/metrics/alert/QuotaAlertNotifierTest.java
+++ b/src/test/java/com/dnd/moyeolak/global/metrics/alert/QuotaAlertNotifierTest.java
@@ -37,6 +37,7 @@ class QuotaAlertNotifierTest {
         properties.setThresholdPercent(20.0);
         clock = Clock.fixed(Instant.parse("2026-07-26T01:00:00Z"), KST);
         notifier = new QuotaAlertNotifier(statsService, slackWebhookClient, properties, clock);
+        when(slackWebhookClient.send(anyString())).thenReturn(true);
     }
 
     private ApiSummary summary(String api, Long dailyQuota, Long quotaRemaining) {
@@ -97,6 +98,19 @@ class QuotaAlertNotifierTest {
 
         Clock nextDay = Clock.fixed(Instant.parse("2026-07-27T01:00:00Z"), KST);
         ReflectionTestUtils.setField(notifier, "clock", nextDay);
+        notifier.checkAndNotify();
+
+        verify(slackWebhookClient, times(2)).send(anyString());
+    }
+
+    @Test
+    @DisplayName("Slack 전송이 실패하면 같은 날에도 다음 주기에 재시도한다")
+    void retriesWithinSameDayWhenSendFails() {
+        when(statsService.summary()).thenReturn(new ExternalApiSummaryResponse(
+                LocalDateTime.now(clock), List.of(summary("odsay", 1000L, 100L))));
+        when(slackWebhookClient.send(anyString())).thenReturn(false);
+
+        notifier.checkAndNotify();
         notifier.checkAndNotify();
 
         verify(slackWebhookClient, times(2)).send(anyString());

--- a/src/test/java/com/dnd/moyeolak/global/metrics/alert/QuotaAlertNotifierTest.java
+++ b/src/test/java/com/dnd/moyeolak/global/metrics/alert/QuotaAlertNotifierTest.java
@@ -1,0 +1,104 @@
+package com.dnd.moyeolak.global.metrics.alert;
+
+import com.dnd.moyeolak.global.client.slack.SlackWebhookClient;
+import com.dnd.moyeolak.global.metrics.stats.ExternalApiStatsService;
+import com.dnd.moyeolak.global.metrics.stats.dto.ExternalApiSummaryResponse;
+import com.dnd.moyeolak.global.metrics.stats.dto.ExternalApiSummaryResponse.ApiSummary;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.*;
+
+class QuotaAlertNotifierTest {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private ExternalApiStatsService statsService;
+    private SlackWebhookClient slackWebhookClient;
+    private ExternalApiAlertProperties properties;
+    private Clock clock;
+    private QuotaAlertNotifier notifier;
+
+    @BeforeEach
+    void setUp() {
+        statsService = mock(ExternalApiStatsService.class);
+        slackWebhookClient = mock(SlackWebhookClient.class);
+        properties = new ExternalApiAlertProperties();
+        properties.setThresholdPercent(20.0);
+        clock = Clock.fixed(Instant.parse("2026-07-26T01:00:00Z"), KST);
+        notifier = new QuotaAlertNotifier(statsService, slackWebhookClient, properties, clock);
+    }
+
+    private ApiSummary summary(String api, Long dailyQuota, Long quotaRemaining) {
+        return new ApiSummary(api, 0, 0, 0, 0.0, 0, 0.0, dailyQuota, quotaRemaining, null);
+    }
+
+    @Test
+    @DisplayName("잔여 비율이 임계치 미만이면 Slack 알림을 보낸다")
+    void notifiesWhenBelowThreshold() {
+        when(statsService.summary()).thenReturn(new ExternalApiSummaryResponse(
+                LocalDateTime.now(clock), List.of(summary("odsay", 1000L, 100L)))); // 10% 남음
+
+        notifier.checkAndNotify();
+
+        verify(slackWebhookClient).send(contains("odsay"));
+    }
+
+    @Test
+    @DisplayName("잔여 비율이 임계치 이상이면 알림을 보내지 않는다")
+    void doesNotNotifyWhenAboveThreshold() {
+        when(statsService.summary()).thenReturn(new ExternalApiSummaryResponse(
+                LocalDateTime.now(clock), List.of(summary("odsay", 1000L, 500L)))); // 50% 남음
+
+        notifier.checkAndNotify();
+
+        verify(slackWebhookClient, never()).send(anyString());
+    }
+
+    @Test
+    @DisplayName("dailyQuota가 없는 API(Google Routes)는 검사 대상에서 제외한다")
+    void skipsApiWithoutDailyQuota() {
+        when(statsService.summary()).thenReturn(new ExternalApiSummaryResponse(
+                LocalDateTime.now(clock), List.of(summary("google_routes", null, null))));
+
+        notifier.checkAndNotify();
+
+        verify(slackWebhookClient, never()).send(anyString());
+    }
+
+    @Test
+    @DisplayName("같은 날 같은 API는 한 번만 알림을 보낸다")
+    void deduplicatesWithinSameDay() {
+        when(statsService.summary()).thenReturn(new ExternalApiSummaryResponse(
+                LocalDateTime.now(clock), List.of(summary("odsay", 1000L, 100L))));
+
+        notifier.checkAndNotify();
+        notifier.checkAndNotify();
+
+        verify(slackWebhookClient, times(1)).send(anyString());
+    }
+
+    @Test
+    @DisplayName("날짜가 바뀌면 같은 API도 다시 알림을 보낸다")
+    void resendsAfterDateChanges() {
+        when(statsService.summary()).thenReturn(new ExternalApiSummaryResponse(
+                LocalDateTime.now(clock), List.of(summary("odsay", 1000L, 100L))));
+        notifier.checkAndNotify();
+
+        Clock nextDay = Clock.fixed(Instant.parse("2026-07-27T01:00:00Z"), KST);
+        QuotaAlertNotifier notifierNextDay =
+                new QuotaAlertNotifier(statsService, slackWebhookClient, properties, nextDay);
+        notifierNextDay.checkAndNotify();
+
+        verify(slackWebhookClient, times(2)).send(anyString());
+    }
+}

--- a/src/test/java/com/dnd/moyeolak/global/metrics/alert/QuotaAlertNotifierTest.java
+++ b/src/test/java/com/dnd/moyeolak/global/metrics/alert/QuotaAlertNotifierTest.java
@@ -7,6 +7,7 @@ import com.dnd.moyeolak.global.metrics.stats.dto.ExternalApiSummaryResponse.ApiS
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -95,9 +96,8 @@ class QuotaAlertNotifierTest {
         notifier.checkAndNotify();
 
         Clock nextDay = Clock.fixed(Instant.parse("2026-07-27T01:00:00Z"), KST);
-        QuotaAlertNotifier notifierNextDay =
-                new QuotaAlertNotifier(statsService, slackWebhookClient, properties, nextDay);
-        notifierNextDay.checkAndNotify();
+        ReflectionTestUtils.setField(notifier, "clock", nextDay);
+        notifier.checkAndNotify();
 
         verify(slackWebhookClient, times(2)).send(anyString());
     }


### PR DESCRIPTION
## Summary
- 외부 API(ODsay/Kakao Local/Kakao Directions) 일일 호출 quota 잔여 비율이 임계치(기본 20%) 미만이면 Slack Incoming Webhook으로 알림 (`SlackWebhookClient`, `QuotaAlertNotifier`)
- 기존 5분 주기 `MetricsSnapshotJob`에 훅으로 연결, 같은 날 같은 API 중복 알림 방지
- 매일 지정 시각(기본 23:50)에 오늘 생성된 모임 수 + 외부 API 호출 통계를 요약해 Slack으로 전송 (`DailySummaryNotifier`) — 기존 `MeetingService.getLandingStats()` / `ExternalApiStatsService.summary()` 재사용, 신규 계측 없음

## Review 과정에서 발견되어 수정한 이슈
- 중복 방지 맵의 TOCTOU 경쟁 상태 → `Map.put()` 반환값으로 원자적 처리
- 웹훅 URL(시크릿)이 예외 메시지를 통해 ERROR 로그에 유출될 수 있었음 → 예외 클래스명만 로깅하도록 수정
- Slack 전송 성공 확인 전에 "오늘 알림 완료"로 기록되어, 일시적 전송 실패 시 해당 API가 하루 종일 재시도되지 않던 문제 → `send()`가 성공 여부를 반환하도록 바꾸고 실패 시 재시도 가능하도록 수정

## 배포 전 필요 작업 (이 PR 범위 밖)
- Slack Incoming Webhook 앱 생성 및 `SLACK_WEBHOOK_URL` 시크릿/환경변수 등록 필요 (webhook URL 미설정 시 기능은 안전하게 비활성 상태로 동작)
- 서버다운/메모리/AWS 요금 알림(CloudWatch·SNS·Chatbot·Budgets)은 별도 인프라 작업으로 미착수

## Test plan
- [x] `./gradlew test` 전체 통과 (dev 최신 반영 후 재확인)
- [x] 신규 컴포넌트 단위 테스트: `SlackWebhookClientTest`, `QuotaAlertNotifierTest`, `DailySummaryNotifierTest`
- [ ] 실제 Slack 채널 수신 확인 (webhook 발급 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)