### PR TITLE
AWS 크레딧 잔액 일일 Slack 알림 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'com.github.ben-manes.caffeine:caffeine'
 
+    // AWS Cost Explorer (크레딧 잔액 Slack 알림)
+    implementation platform('software.amazon.awssdk:bom:2.32.14')
+    implementation('software.amazon.awssdk:costexplorer') {
+        exclude group: 'software.amazon.awssdk', module: 'netty-nio-client'
+        exclude group: 'software.amazon.awssdk', module: 'apache-client'
+    }
+    implementation 'software.amazon.awssdk:url-connection-client'
+
     // Monitoring
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'

--- a/docs/aws-credit-slack-alert.md
+++ b/docs/aws-credit-slack-alert.md
@@ -1,0 +1,106 @@
+# AWS 크레딧 잔액 Slack 알림 설정
+
+매일 09:00(KST) AWS 크레딧 차감 현황을 Slack으로 보낸다.
+구현: `global/client/aws/AwsCostExplorerClient`, `global/metrics/alert/AwsCreditNotifier`
+
+## 왜 크레딧 총액을 직접 설정해야 하나
+
+AWS는 **크레딧 잔액을 조회하는 공개 API를 제공하지 않는다.** 콘솔의
+[Credits 페이지](https://console.aws.amazon.com/billing/home#/credits)에서만 볼 수 있다.
+
+그래서 이 알림은 다음처럼 잔액을 낸다.
+
+```
+잔액 = AWS_CREDIT_TOTAL (수동 설정) - Cost Explorer가 보고한 누적 크레딧 차감액
+```
+
+`AWS_CREDIT_TOTAL`이 비어 있으면 잔액 줄 없이 누적 사용액·일평균만 보낸다.
+크레딧을 추가로 부여받으면 이 값을 직접 올려야 한다.
+
+## 준비 1: 읽기 전용 IAM 사용자
+
+배포용 AWS 키와 섞지 않기 위해 별도 사용자를 만든다.
+
+```bash
+aws iam create-user --user-name moyeolak-cost-reader
+
+cat > /tmp/cost-reader-policy.json <<'JSON'
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["ce:GetCostAndUsage"],
+      "Resource": "*"
+    }
+  ]
+}
+JSON
+
+aws iam put-user-policy \
+  --user-name moyeolak-cost-reader \
+  --policy-name CostExplorerReadOnly \
+  --policy-document file:///tmp/cost-reader-policy.json
+
+aws iam create-access-key --user-name moyeolak-cost-reader
+```
+
+마지막 명령이 출력하는 `AccessKeyId` / `SecretAccessKey`를 아래 `.env`에 넣는다.
+
+> Cost Explorer가 콘솔에서 한 번도 활성화되지 않았다면 API가 빈 데이터를 돌려준다.
+> Billing 콘솔 > Cost Explorer를 한 번 열어 활성화한다.
+
+## 준비 2: EC2 `.env`
+
+`/app/moyeolak/.env`에 추가한다. `docker-compose.prod.yml`이 이 값을 컨테이너로 넘긴다.
+
+```bash
+AWS_COST_ALERT_ENABLED=true
+AWS_COST_ACCESS_KEY_ID=AKIA...
+AWS_COST_SECRET_ACCESS_KEY=...
+AWS_CREDIT_TOTAL=300           # 콘솔 Credits 페이지에서 확인한 부여 총액(USD)
+AWS_CREDIT_START_DATE=2026-07-01
+```
+
+`AWS_COST_ALERT_ENABLED`가 `false`(기본값)면 관련 빈이 아예 생성되지 않는다.
+
+## 설정 항목
+
+| 프로퍼티 | 환경변수 | 기본값 | 설명 |
+|---|---|---|---|
+| `aws.cost.enabled` | `AWS_COST_ALERT_ENABLED` | `false` | 알림 on/off. 꺼지면 SDK 클라이언트도 안 만든다 |
+| `aws.cost.access-key` | `AWS_COST_ACCESS_KEY_ID` | (빈값) | 비우면 SDK 기본 자격증명 체인 사용 |
+| `aws.cost.secret-key` | `AWS_COST_SECRET_ACCESS_KEY` | (빈값) | |
+| `aws.cost.credit-total` | `AWS_CREDIT_TOTAL` | (빈값) | 부여 크레딧 총액(USD). 비우면 잔액 계산 생략 |
+| `aws.cost.credit-start-date` | `AWS_CREDIT_START_DATE` | `2026-07-01` | 누적 차감 집계 시작일 |
+| `aws.cost.cron` | — | `0 0 9 * * *` | 발송 시각 |
+
+## 메시지 예시
+
+```
+:moneybag: AWS 크레딧 현황 (2026-08-18 기준)
+
+남은 크레딧: $290.77 / $300.00 (96.9%)
+누적 사용: $9.23 (2026-07-01 이후)
+이번 달 사용: $3.79
+최근 7일 일평균: $0.21
+소진 예상: 2030-06-09 (1391일 남음)
+```
+
+## 알아둘 것
+
+- **Cost Explorer 데이터는 약 24시간 지연된다.** 메시지의 "기준" 날짜는 어제다.
+  당일 데이터는 부분 집계라 일평균에서 제외한다.
+- **Cost Explorer API는 요청당 $0.01.** 하루 2회 호출하므로 월 약 $0.6.
+- 크레딧은 Cost Explorer에서 음수(`RECORD_TYPE=Credit`)로 내려온다. 코드가 절대값으로 뒤집어 "사용액"으로 다룬다.
+- 조회에 실패하면 로그만 남기고 Slack 전송을 건너뛴다. 애플리케이션 동작에는 영향이 없다.
+
+## 수동 확인
+
+```bash
+# 누적 크레딧 차감
+aws ce get-cost-and-usage --region us-east-1 \
+  --time-period Start=2026-07-01,End=$(date -u -v+1d +%Y-%m-%d) \
+  --granularity MONTHLY --metrics UnblendedCost \
+  --filter '{"Dimensions":{"Key":"RECORD_TYPE","Values":["Credit"]}}'
+```

--- a/infra/deploy/docker-compose.prod.yml
+++ b/infra/deploy/docker-compose.prod.yml
@@ -37,6 +37,13 @@ services:
       ADMIN_TOKEN: ${ADMIN_TOKEN}
       # Slack 알림용 Incoming Webhook URL. 서버 /app/moyeolak/.env 에 정의. 미설정 시 알림 기능 비활성.
       SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL:-}
+      # AWS 크레딧 잔액 Slack 알림. ce:GetCostAndUsage 만 가진 읽기 전용 IAM 키를 쓴다.
+      # (배포용 AWS 키와 분리하려고 이름을 AWS_COST_* 로 둔다.) 미설정 시 알림 비활성.
+      AWS_COST_ALERT_ENABLED: ${AWS_COST_ALERT_ENABLED:-false}
+      AWS_COST_ACCESS_KEY_ID: ${AWS_COST_ACCESS_KEY_ID:-}
+      AWS_COST_SECRET_ACCESS_KEY: ${AWS_COST_SECRET_ACCESS_KEY:-}
+      AWS_CREDIT_TOTAL: ${AWS_CREDIT_TOTAL:-}
+      AWS_CREDIT_START_DATE: ${AWS_CREDIT_START_DATE:-2026-07-01}
       # 2GB 인스턴스에서 힙 폭주 방지
       JAVA_TOOL_OPTIONS: "-XX:MaxRAMPercentage=50.0 -Duser.timezone=Asia/Seoul"
     volumes:

--- a/src/main/java/com/dnd/moyeolak/global/client/aws/AwsCostExplorerClient.java
+++ b/src/main/java/com/dnd/moyeolak/global/client/aws/AwsCostExplorerClient.java
@@ -1,0 +1,84 @@
+package com.dnd.moyeolak.global.client.aws;
+
+import com.dnd.moyeolak.global.client.aws.dto.AwsCostSnapshot;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.costexplorer.CostExplorerClient;
+import software.amazon.awssdk.services.costexplorer.model.*;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+/**
+ * Cost Explorer의 RECORD_TYPE=Credit 레코드를 읽어 크레딧 차감 현황을 만든다.
+ * 크레딧 잔액 자체를 주는 API는 없으므로, 차감액 누적치만 여기서 계산하고
+ * 잔액은 설정된 부여 총액에서 빼는 방식으로 {@link com.dnd.moyeolak.global.metrics.alert.AwsCreditNotifier}가 구한다.
+ */
+@Component
+@ConditionalOnProperty(name = "aws.cost.enabled", havingValue = "true")
+public class AwsCostExplorerClient {
+
+    private static final DateTimeFormatter DATE = DateTimeFormatter.ISO_LOCAL_DATE;
+    private static final String METRIC = "UnblendedCost";
+    private static final int DAILY_AVERAGE_WINDOW_DAYS = 7;
+
+    private final CostExplorerClient costExplorerClient;
+
+    public AwsCostExplorerClient(CostExplorerClient costExplorerClient) {
+        this.costExplorerClient = costExplorerClient;
+    }
+
+    public AwsCostSnapshot fetch(LocalDate creditStartDate, LocalDate today) {
+        // Cost Explorer의 End는 배타적이라 오늘까지 포함하려면 +1일
+        List<ResultByTime> monthly = query(Granularity.MONTHLY, creditStartDate, today.plusDays(1));
+        // 당일 데이터는 부분 집계라 일평균을 왜곡하므로 오늘 직전 7일만 본다
+        List<ResultByTime> daily = query(Granularity.DAILY, today.minusDays(DAILY_AVERAGE_WINDOW_DAYS), today);
+
+        return new AwsCostSnapshot(
+                sum(monthly),
+                monthly.isEmpty() ? BigDecimal.ZERO : amountOf(monthly.getLast()),
+                average(daily),
+                today.minusDays(1));
+    }
+
+    private List<ResultByTime> query(Granularity granularity, LocalDate start, LocalDate end) {
+        GetCostAndUsageRequest request = GetCostAndUsageRequest.builder()
+                .timePeriod(DateInterval.builder()
+                        .start(start.format(DATE))
+                        .end(end.format(DATE))
+                        .build())
+                .granularity(granularity)
+                .metrics(METRIC)
+                .filter(Expression.builder()
+                        .dimensions(DimensionValues.builder()
+                                .key(Dimension.RECORD_TYPE)
+                                .values("Credit")
+                                .build())
+                        .build())
+                .build();
+        return costExplorerClient.getCostAndUsage(request).resultsByTime();
+    }
+
+    /** 크레딧은 음수로 내려오므로 절대값으로 뒤집어 "사용액"으로 다룬다. */
+    private BigDecimal amountOf(ResultByTime bucket) {
+        MetricValue value = bucket.total().get(METRIC);
+        if (value == null || value.amount() == null) {
+            return BigDecimal.ZERO;
+        }
+        return new BigDecimal(value.amount()).abs();
+    }
+
+    private BigDecimal sum(List<ResultByTime> buckets) {
+        return buckets.stream().map(this::amountOf).reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    private BigDecimal average(List<ResultByTime> buckets) {
+        if (buckets.isEmpty()) {
+            return BigDecimal.ZERO;
+        }
+        return sum(buckets).divide(BigDecimal.valueOf(buckets.size()), MathContext.DECIMAL64);
+    }
+}

--- a/src/main/java/com/dnd/moyeolak/global/client/aws/config/AwsCostConfig.java
+++ b/src/main/java/com/dnd/moyeolak/global/client/aws/config/AwsCostConfig.java
@@ -1,0 +1,46 @@
+package com.dnd.moyeolak.global.client.aws.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.costexplorer.CostExplorerClient;
+import software.amazon.awssdk.services.costexplorer.CostExplorerClientBuilder;
+
+import java.time.Duration;
+
+/**
+ * Cost Explorer 클라이언트. 알림이 꺼져 있으면 SDK 클라이언트를 아예 만들지 않는다.
+ */
+@Configuration
+@ConditionalOnProperty(name = "aws.cost.enabled", havingValue = "true")
+public class AwsCostConfig {
+
+    /**
+     * Cost Explorer는 리전 단위 서비스가 아니라 us-east-1 글로벌 엔드포인트만 받는다.
+     * 키가 비어 있으면 EC2 인스턴스 프로파일 등 SDK 기본 자격증명 체인으로 넘어간다.
+     */
+    @Bean
+    public CostExplorerClient costExplorerClient(
+            @Value("${aws.cost.access-key:}") String accessKey,
+            @Value("${aws.cost.secret-key:}") String secretKey
+    ) {
+        CostExplorerClientBuilder builder = CostExplorerClient.builder()
+                .region(Region.US_EAST_1)
+                .httpClient(UrlConnectionHttpClient.builder()
+                        .connectionTimeout(Duration.ofSeconds(5))
+                        .socketTimeout(Duration.ofSeconds(10))
+                        .build());
+
+        // 키를 지정하지 않으면 SDK 기본 자격증명 체인(환경변수, 인스턴스 프로파일 등)을 그대로 쓴다
+        if (!accessKey.isBlank() && !secretKey.isBlank()) {
+            builder.credentialsProvider(StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(accessKey, secretKey)));
+        }
+        return builder.build();
+    }
+}

--- a/src/main/java/com/dnd/moyeolak/global/client/aws/dto/AwsCostSnapshot.java
+++ b/src/main/java/com/dnd/moyeolak/global/client/aws/dto/AwsCostSnapshot.java
@@ -1,0 +1,20 @@
+package com.dnd.moyeolak.global.client.aws.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * Cost Explorer에서 읽어온 크레딧 차감 현황. 금액은 모두 USD 양수로 정규화한다.
+ *
+ * @param totalCreditsUsed        크레딧 시작일 이후 누적 차감액
+ * @param monthToDateCreditsUsed  이번 달 차감액
+ * @param recentDailyAverage      최근 7일 일평균 차감액
+ * @param dataThrough             집계에 반영된 마지막 날짜 (Cost Explorer는 약 24h 지연)
+ */
+public record AwsCostSnapshot(
+        BigDecimal totalCreditsUsed,
+        BigDecimal monthToDateCreditsUsed,
+        BigDecimal recentDailyAverage,
+        LocalDate dataThrough
+) {
+}

--- a/src/main/java/com/dnd/moyeolak/global/metrics/alert/AwsCreditNotifier.java
+++ b/src/main/java/com/dnd/moyeolak/global/metrics/alert/AwsCreditNotifier.java
@@ -1,0 +1,137 @@
+package com.dnd.moyeolak.global.metrics.alert;
+
+import com.dnd.moyeolak.global.client.aws.AwsCostExplorerClient;
+import com.dnd.moyeolak.global.client.aws.dto.AwsCostSnapshot;
+import com.dnd.moyeolak.global.client.slack.SlackWebhookClient;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * 매일 지정 시각에 AWS 크레딧 차감 현황을 Slack으로 전송한다.
+ *
+ * <p>AWS는 크레딧 잔액 조회 API를 제공하지 않는다. 그래서 부여받은 총액을 설정값
+ * ({@code aws.cost.credit-total})으로 받아두고, Cost Explorer가 보고한 누적 차감액을 빼서 잔액을 낸다.
+ * 총액이 없으면 잔액 없이 사용액만 보낸다.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "aws.cost.enabled", havingValue = "true")
+public class AwsCreditNotifier {
+
+    private static final DateTimeFormatter DATE = DateTimeFormatter.ISO_LOCAL_DATE;
+    /** 일평균이 0에 가까우면 소진일이 서기 79만년 같은 값으로 나온다. 그 위로는 날짜를 쓰지 않는다. */
+    private static final BigDecimal MAX_FORECAST_DAYS = BigDecimal.valueOf(3650);
+
+    private final AwsCostExplorerClient awsCostExplorerClient;
+    private final SlackWebhookClient slackWebhookClient;
+    private final Clock clock;
+    private final BigDecimal creditTotal;
+    private final LocalDate creditStartDate;
+
+    public AwsCreditNotifier(
+            AwsCostExplorerClient awsCostExplorerClient,
+            SlackWebhookClient slackWebhookClient,
+            Clock clock,
+            @Value("${aws.cost.credit-total:}") String creditTotal,
+            @Value("${aws.cost.credit-start-date:2026-07-01}") String creditStartDate
+    ) {
+        this.awsCostExplorerClient = awsCostExplorerClient;
+        this.slackWebhookClient = slackWebhookClient;
+        this.clock = clock;
+        this.creditTotal = parseCreditTotal(creditTotal);
+        this.creditStartDate = LocalDate.parse(creditStartDate.trim(), DATE);
+    }
+
+    @Scheduled(cron = "${aws.cost.cron:0 0 9 * * *}")
+    public void sendCreditStatus() {
+        LocalDate today = LocalDate.now(clock);
+        AwsCostSnapshot snapshot;
+        try {
+            snapshot = awsCostExplorerClient.fetch(creditStartDate, today);
+        } catch (Exception e) {
+            // 요금 알림 실패가 애플리케이션에 영향을 주면 안 되므로 로그만 남기고 조용히 넘어간다
+            log.error("AWS Cost Explorer 조회 실패 - 크레딧 알림 생략: {}", e.toString());
+            return;
+        }
+        slackWebhookClient.send(buildMessage(snapshot));
+    }
+
+    private String buildMessage(AwsCostSnapshot snapshot) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(":moneybag: AWS 크레딧 현황 (")
+                .append(snapshot.dataThrough().format(DATE))
+                .append(" 기준)\n\n");
+
+        if (creditTotal != null) {
+            appendBalance(sb, snapshot);
+        }
+        sb.append("누적 사용: ").append(usd(snapshot.totalCreditsUsed()))
+                .append(" (").append(creditStartDate.format(DATE)).append(" 이후)\n");
+        sb.append("이번 달 사용: ").append(usd(snapshot.monthToDateCreditsUsed())).append('\n');
+        sb.append("최근 7일 일평균: ").append(usd(snapshot.recentDailyAverage())).append('\n');
+
+        if (creditTotal != null) {
+            appendDepletionForecast(sb, snapshot);
+        } else {
+            sb.append("\n크레딧 총액이 설정되지 않아 잔액을 계산하지 못했습니다. ")
+                    .append("AWS_CREDIT_TOTAL 환경변수를 설정하세요.\n");
+        }
+        return sb.toString();
+    }
+
+    private void appendBalance(StringBuilder sb, AwsCostSnapshot snapshot) {
+        BigDecimal remaining = remaining(snapshot);
+        BigDecimal percent = creditTotal.signum() == 0
+                ? BigDecimal.ZERO
+                : remaining.multiply(BigDecimal.valueOf(100)).divide(creditTotal, MathContext.DECIMAL64);
+        sb.append("남은 크레딧: ").append(usd(remaining)).append(" / ").append(usd(creditTotal))
+                .append(" (").append(percent.setScale(1, RoundingMode.HALF_UP)).append("%)\n");
+    }
+
+    private void appendDepletionForecast(StringBuilder sb, AwsCostSnapshot snapshot) {
+        BigDecimal remaining = remaining(snapshot);
+        BigDecimal dailyAverage = snapshot.recentDailyAverage();
+        if (dailyAverage.signum() <= 0 || remaining.signum() <= 0) {
+            return;
+        }
+        BigDecimal daysLeft = remaining.divide(dailyAverage, MathContext.DECIMAL64)
+                .setScale(0, RoundingMode.DOWN);
+        if (daysLeft.compareTo(MAX_FORECAST_DAYS) > 0) {
+            sb.append("소진 예상: 10년 이상 남음\n");
+            return;
+        }
+        long days = daysLeft.longValueExact();
+        sb.append("소진 예상: ").append(snapshot.dataThrough().plusDays(days).format(DATE))
+                .append(" (").append(days).append("일 남음)\n");
+    }
+
+    private BigDecimal remaining(AwsCostSnapshot snapshot) {
+        return creditTotal.subtract(snapshot.totalCreditsUsed()).max(BigDecimal.ZERO);
+    }
+
+    private String usd(BigDecimal amount) {
+        return "$" + amount.setScale(2, RoundingMode.HALF_UP).toPlainString();
+    }
+
+    private static BigDecimal parseCreditTotal(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        try {
+            return new BigDecimal(raw.trim());
+        } catch (NumberFormatException e) {
+            log.warn("aws.cost.credit-total 값을 숫자로 읽을 수 없어 잔액 계산을 생략합니다: {}", raw);
+            return null;
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,18 @@ external-api:
     threshold-percent: 20             # 일일 quota 잔여 비율이 이 값(%) 미만이면 Slack 알림
     slack-webhook-url: ${SLACK_WEBHOOK_URL:}
     daily-summary-cron: "0 50 23 * * *"   # 매일 23:50 오늘 통계 요약 발송
+# AWS 크레딧 잔액 Slack 알림. Cost Explorer(us-east-1) 조회 -> 매일 1회 발송.
+# AWS는 크레딧 잔액 조회 API를 제공하지 않으므로 부여 총액을 직접 설정해야 잔액이 계산된다.
+# 미설정 시 누적 사용액/일평균만 발송한다. https://console.aws.amazon.com/billing/home#/credits
+aws:
+  cost:
+    enabled: ${AWS_COST_ALERT_ENABLED:false}
+    access-key: ${AWS_COST_ACCESS_KEY_ID:}
+    secret-key: ${AWS_COST_SECRET_ACCESS_KEY:}
+    credit-total: ${AWS_CREDIT_TOTAL:}        # 부여받은 크레딧 총액(USD). 예: 300
+    credit-start-date: ${AWS_CREDIT_START_DATE:2026-07-01}   # 크레딧 차감 집계 시작일
+    cron: "0 0 9 * * *"                       # 매일 09:00 발송 (CE 데이터는 약 24h 지연)
+
 moyeolak:
   rate-limit:
     midpoint-recommendation:

--- a/src/test/java/com/dnd/moyeolak/global/client/aws/AwsCostExplorerClientTest.java
+++ b/src/test/java/com/dnd/moyeolak/global/client/aws/AwsCostExplorerClientTest.java
@@ -1,0 +1,130 @@
+package com.dnd.moyeolak.global.client.aws;
+
+import com.dnd.moyeolak.global.client.aws.dto.AwsCostSnapshot;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.services.costexplorer.CostExplorerClient;
+import software.amazon.awssdk.services.costexplorer.model.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class AwsCostExplorerClientTest {
+
+    private static final LocalDate CREDIT_START = LocalDate.of(2026, 7, 1);
+    private static final LocalDate TODAY = LocalDate.of(2026, 8, 19);
+
+    private CostExplorerClient sdk;
+    private AwsCostExplorerClient client;
+
+    @BeforeEach
+    void setUp() {
+        sdk = mock(CostExplorerClient.class);
+        client = new AwsCostExplorerClient(sdk);
+    }
+
+    private static ResultByTime bucket(String start, String end, String amount) {
+        return ResultByTime.builder()
+                .timePeriod(DateInterval.builder().start(start).end(end).build())
+                .total(Map.of("UnblendedCost", MetricValue.builder().amount(amount).unit("USD").build()))
+                .build();
+    }
+
+    private static GetCostAndUsageResponse response(ResultByTime... buckets) {
+        return GetCostAndUsageResponse.builder().resultsByTime(List.of(buckets)).build();
+    }
+
+    /** MONTHLY 요청과 DAILY 요청에 서로 다른 응답을 돌려준다. */
+    private void stubSdk(GetCostAndUsageResponse monthly, GetCostAndUsageResponse daily) {
+        when(sdk.getCostAndUsage(any(GetCostAndUsageRequest.class))).thenAnswer(invocation -> {
+            GetCostAndUsageRequest request = invocation.getArgument(0);
+            return request.granularity() == Granularity.MONTHLY ? monthly : daily;
+        });
+    }
+
+    @Test
+    @DisplayName("음수로 내려오는 월별 크레딧을 절대값으로 합산해 누적 사용액을 만든다")
+    void sumsMonthlyCreditsAsPositiveTotal() {
+        stubSdk(
+                response(
+                        bucket("2026-07-01", "2026-08-01", "-5.4366630976"),
+                        bucket("2026-08-01", "2026-08-20", "-3.7894508568")),
+                response(bucket("2026-08-18", "2026-08-19", "-0.2089961591")));
+
+        AwsCostSnapshot snapshot = client.fetch(CREDIT_START, TODAY);
+
+        assertThat(snapshot.totalCreditsUsed().doubleValue()).isCloseTo(9.2261139544, within(0.0000001));
+        assertThat(snapshot.monthToDateCreditsUsed().doubleValue()).isCloseTo(3.7894508568, within(0.0000001));
+    }
+
+    @Test
+    @DisplayName("최근 일별 크레딧 사용액의 평균을 일평균으로 계산한다")
+    void averagesRecentDailyCredits() {
+        stubSdk(
+                response(bucket("2026-08-01", "2026-08-20", "-3.0")),
+                response(
+                        bucket("2026-08-16", "2026-08-17", "-0.10"),
+                        bucket("2026-08-17", "2026-08-18", "-0.20"),
+                        bucket("2026-08-18", "2026-08-19", "-0.30")));
+
+        AwsCostSnapshot snapshot = client.fetch(CREDIT_START, TODAY);
+
+        assertThat(snapshot.recentDailyAverage().doubleValue()).isCloseTo(0.20, within(0.0000001));
+    }
+
+    @Test
+    @DisplayName("데이터 기준일은 어제다 - Cost Explorer는 당일 데이터가 불완전하다")
+    void reportsYesterdayAsDataThrough() {
+        stubSdk(response(bucket("2026-08-01", "2026-08-20", "-3.0")),
+                response(bucket("2026-08-18", "2026-08-19", "-0.2")));
+
+        AwsCostSnapshot snapshot = client.fetch(CREDIT_START, TODAY);
+
+        assertThat(snapshot.dataThrough()).isEqualTo(LocalDate.of(2026, 8, 18));
+    }
+
+    @Test
+    @DisplayName("집계 구간에 데이터가 없으면 0으로 채운다")
+    void fillsZeroWhenNoData() {
+        stubSdk(response(), response());
+
+        AwsCostSnapshot snapshot = client.fetch(CREDIT_START, TODAY);
+
+        assertThat(snapshot.totalCreditsUsed()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(snapshot.monthToDateCreditsUsed()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(snapshot.recentDailyAverage()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    @DisplayName("누적 조회는 크레딧 시작일부터 오늘까지, 일평균 조회는 오늘 직전 7일을 대상으로 한다")
+    void queriesExpectedTimePeriods() {
+        stubSdk(response(bucket("2026-08-01", "2026-08-20", "-3.0")),
+                response(bucket("2026-08-18", "2026-08-19", "-0.2")));
+
+        client.fetch(CREDIT_START, TODAY);
+
+        ArgumentCaptor<GetCostAndUsageRequest> captor = ArgumentCaptor.forClass(GetCostAndUsageRequest.class);
+        verify(sdk, times(2)).getCostAndUsage(captor.capture());
+
+        GetCostAndUsageRequest monthly = captor.getAllValues().stream()
+                .filter(r -> r.granularity() == Granularity.MONTHLY).findFirst().orElseThrow();
+        assertThat(monthly.timePeriod().start()).isEqualTo("2026-07-01");
+        assertThat(monthly.timePeriod().end()).isEqualTo("2026-08-20");   // End는 배타적이라 오늘 포함하려면 +1일
+        assertThat(monthly.filter().dimensions().key()).isEqualTo(Dimension.RECORD_TYPE);
+        assertThat(monthly.filter().dimensions().values()).containsExactly("Credit");
+
+        GetCostAndUsageRequest daily = captor.getAllValues().stream()
+                .filter(r -> r.granularity() == Granularity.DAILY).findFirst().orElseThrow();
+        assertThat(daily.timePeriod().start()).isEqualTo("2026-08-12");
+        assertThat(daily.timePeriod().end()).isEqualTo("2026-08-19");     // 오늘은 부분 데이터라 제외
+    }
+}

--- a/src/test/java/com/dnd/moyeolak/global/metrics/alert/AwsCreditNotifierTest.java
+++ b/src/test/java/com/dnd/moyeolak/global/metrics/alert/AwsCreditNotifierTest.java
@@ -1,0 +1,147 @@
+package com.dnd.moyeolak.global.metrics.alert;
+
+import com.dnd.moyeolak.global.client.aws.AwsCostExplorerClient;
+import com.dnd.moyeolak.global.client.aws.dto.AwsCostSnapshot;
+import com.dnd.moyeolak.global.client.slack.SlackWebhookClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class AwsCreditNotifierTest {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-08-19T00:00:00Z"), KST);
+    private static final String CREDIT_START = "2026-07-01";
+
+    private AwsCostExplorerClient costExplorerClient;
+    private SlackWebhookClient slackWebhookClient;
+
+    @BeforeEach
+    void setUp() {
+        costExplorerClient = mock(AwsCostExplorerClient.class);
+        slackWebhookClient = mock(SlackWebhookClient.class);
+        when(slackWebhookClient.send(anyString())).thenReturn(true);
+    }
+
+    private AwsCreditNotifier notifier(String creditTotal) {
+        return new AwsCreditNotifier(costExplorerClient, slackWebhookClient, CLOCK, creditTotal, CREDIT_START);
+    }
+
+    private void givenSnapshot(String totalUsed, String monthToDate, String dailyAverage) {
+        when(costExplorerClient.fetch(any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(new AwsCostSnapshot(
+                        new BigDecimal(totalUsed),
+                        new BigDecimal(monthToDate),
+                        new BigDecimal(dailyAverage),
+                        LocalDate.of(2026, 8, 18)));
+    }
+
+    private String captureSentMessage() {
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(slackWebhookClient).send(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    @DisplayName("크레딧 총액이 설정되면 잔액과 소진 예상일을 메시지에 포함한다")
+    void includesRemainingCreditAndDepletionDateWhenTotalConfigured() {
+        givenSnapshot("9.2261", "3.7895", "0.2090");
+
+        notifier("300").sendCreditStatus();
+
+        String message = captureSentMessage();
+        assertThat(message).contains("$290.77");          // 300 - 9.2261
+        assertThat(message).contains("$300.00");
+        assertThat(message).contains("96.9%");            // 290.7739 / 300
+        assertThat(message).contains("$9.23");            // 누적 사용
+        assertThat(message).contains("$3.79");            // 이번 달 사용
+        assertThat(message).contains("$0.21");            // 일평균
+        assertThat(message).contains("2026-08-18");       // 데이터 기준일
+        assertThat(message).contains("소진 예상");
+        assertThat(message).contains("1391일");           // 290.7739 / 0.2090 내림
+    }
+
+    @Test
+    @DisplayName("크레딧 총액이 없으면 잔액 없이 누적 사용액만 전송한다")
+    void sendsUsageOnlyWhenCreditTotalMissing() {
+        givenSnapshot("9.2261", "3.7895", "0.2090");
+
+        notifier("").sendCreditStatus();
+
+        String message = captureSentMessage();
+        assertThat(message).contains("$9.23");
+        assertThat(message).contains("$3.79");
+        assertThat(message).doesNotContain("남은 크레딧");
+        assertThat(message).doesNotContain("소진 예상");
+        assertThat(message).contains("AWS_CREDIT_TOTAL");
+    }
+
+    @Test
+    @DisplayName("일평균 사용액이 0이면 소진 예상일을 생략한다")
+    void omitsDepletionDateWhenDailyAverageIsZero() {
+        givenSnapshot("9.2261", "0", "0");
+
+        notifier("300").sendCreditStatus();
+
+        String message = captureSentMessage();
+        assertThat(message).contains("남은 크레딧");
+        assertThat(message).doesNotContain("소진 예상");
+    }
+
+    @Test
+    @DisplayName("잔액이 이미 소진되면 남은 크레딧을 0으로 보고한다")
+    void reportsZeroWhenCreditsExhausted() {
+        givenSnapshot("320.5", "40.0", "1.0");
+
+        notifier("300").sendCreditStatus();
+
+        String message = captureSentMessage();
+        assertThat(message).contains("$0.00");
+        assertThat(message).doesNotContain("소진 예상");
+    }
+
+    @Test
+    @DisplayName("일평균이 극히 작아 소진일이 아득하면 날짜 대신 상한 표현을 쓴다")
+    void capsDepletionForecastWhenDailyAverageIsNegligible() {
+        givenSnapshot("9.2261", "0.0000001", "0.0000001");   // 하루 $0.0000001 -> 약 80억 일
+
+        notifier("300").sendCreditStatus();
+
+        String message = captureSentMessage();
+        assertThat(message).contains("10년 이상");
+        assertThat(message).doesNotContain("일 남음");
+    }
+
+    @Test
+    @DisplayName("Cost Explorer 조회에 실패하면 Slack으로 전송하지 않는다")
+    void doesNotSendWhenCostExplorerFails() {
+        when(costExplorerClient.fetch(any(LocalDate.class), any(LocalDate.class)))
+                .thenThrow(new RuntimeException("AccessDeniedException"));
+
+        notifier("300").sendCreditStatus();
+
+        verify(slackWebhookClient, never()).send(anyString());
+    }
+
+    @Test
+    @DisplayName("크레딧 시작일과 오늘 날짜로 Cost Explorer를 조회한다")
+    void queriesCostExplorerWithConfiguredRange() {
+        givenSnapshot("9.2261", "3.7895", "0.2090");
+
+        notifier("300").sendCreditStatus();
+
+        verify(costExplorerClient).fetch(LocalDate.of(2026, 7, 1), LocalDate.of(2026, 8, 19));
+    }
+}


### PR DESCRIPTION
## 요약

매일 09:00(KST) AWS 크레딧 차감 현황을 Slack으로 보냅니다. 기존 `SlackWebhookClient`와 `DailySummaryNotifier` 패턴을 그대로 따랐습니다.

```
:moneybag: AWS 크레딧 현황 (2026-08-18 기준)

남은 크레딧: $290.77 / $300.00 (96.9%)
누적 사용: $9.23 (2026-07-01 이후)
이번 달 사용: $3.79
최근 7일 일평균: $0.21
소진 예상: 2030-06-09 (1391일 남음)
```

## 왜 크레딧 총액을 수동 설정하나

**AWS는 크레딧 잔액을 조회하는 공개 API를 제공하지 않습니다.** 콘솔 Credits 페이지에서만 볼 수 있습니다. 그래서 이렇게 계산합니다.

```
잔액 = AWS_CREDIT_TOTAL (수동 설정) − Cost Explorer가 보고한 누적 크레딧 차감액
```

`AWS_CREDIT_TOTAL`이 비어 있으면 잔액 줄 없이 사용액·일평균만 보냅니다. 값 없이도 동작합니다.

## 설계 메모

- **별도 컴포넌트로 분리** — 기존 `DailySummaryNotifier`에 합치지 않았습니다. Cost Explorer 호출이 실패해도 기존 일일 통계 알림은 그대로 나가야 하기 때문입니다. 조회 실패 시 로그만 남기고 전송을 건너뜁니다.
- **`aws.cost.enabled` 기본값 `false`** — 켜기 전까지 SDK 클라이언트를 포함해 관련 빈이 아예 생성되지 않습니다. 로컬/CI 영향 없음.
- **자격증명 분리** — 배포용 AWS 키와 섞이지 않도록 `AWS_COST_*` 접두사를 쓰고, `ce:GetCostAndUsage`만 가진 읽기 전용 IAM 사용자를 별도로 둡니다.
- **Cost Explorer는 us-east-1 글로벌 엔드포인트 전용**이라 리전을 고정했습니다.
- HTTP 클라이언트는 `url-connection-client`만 남기고 netty/apache를 제외해 의존성을 줄였습니다.

## 검증

- 신규 단위 테스트 12건 (notifier 7, client 5), 전체 스위트 **236건 전부 통과**
- **실제 AWS 계정에 한 번 호출해 확인**했습니다. 임시 probe 결과가 CLI 손계산 값과 일치 (probe는 삭제):
  ```
  AwsCostSnapshot[totalCreditsUsed=9.2261139544, monthToDateCreditsUsed=3.7894508568,
                  recentDailyAverage=0.2089972379285714, dataThrough=2026-08-18]
  ```
- TDD 중 발견한 버그 하나 수정: 일평균이 0에 가까우면 `소진 예상: +7963145-08-12 (2907739000일 남음)` 처럼 출력되던 것을, 3650일 초과 시 `10년 이상 남음`으로 바꿨습니다.

## 알아둘 것

- Cost Explorer 데이터는 **약 24시간 지연**됩니다. 메시지의 "기준" 날짜는 어제입니다. 당일 데이터는 부분 집계라 일평균에서 제외합니다.
- Cost Explorer API는 **요청당 $0.01**, 하루 2회 호출이라 월 약 $0.6입니다.
- 크레딧을 추가 부여받으면 `AWS_CREDIT_TOTAL`을 직접 올려야 합니다.

## 머지 후 필요한 작업

1. 콘솔 Credits 페이지에서 부여 총액 확인
2. 읽기 전용 IAM 사용자 생성 + EC2 `/app/moyeolak/.env`에 `AWS_COST_*` / `AWS_CREDIT_*` 추가 (명령어는 `docs/aws-credit-slack-alert.md`)
3. Billing 콘솔에서 Cost Explorer 활성화 (미활성 시 API가 빈 데이터 반환)

연결된 이슈가 없어 브랜치명에 `#0`을 썼습니다. 이슈 번호가 있으면 알려주시면 맞추겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
